### PR TITLE
add Voicemeeter Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,6 @@
 [submodule "IconPacks/RecklessBoon.PoweredSteel"]
 	path = IconPacks/RecklessBoon.PoweredSteel
 	url = https://github.com/RecklessBoon/Macro-Deck-Icon-Powered-Steel.git
+[submodule "Plugins/PhoenixWyllow.VoicemeeterPlugin"]
+	path = Plugins/PhoenixWyllow.VoicemeeterPlugin
+	url = https://github.com/PhoenixWyllow/MacroDeck.Voicemeeter.git


### PR DESCRIPTION
Due to errors with current Microsoft.Win32.Registry in Macro Deck, this plugin requires v5.0.0 (due to libraries used in plugin)