### PR TITLE
Fixes Workflow

### DIFF
--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -35,7 +35,7 @@ jobs:
       
       - name: Set Upstream
         run: |
-          git remote add upstream git@github.com:Macro-Deck-org/Macro-Deck-Extensions.git
+          git remote add upstream https://github.com/Macro-Deck-org/Macro-Deck-Extensions.git
           git fetch upstream main
           git branch --set-upstream-to upstream/main
       

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update ${{ inputs.ext_type }} - ${{ inputs.package_id }}
-          title: '[${{ inputs.ext_type }} Update] ${{ inputs.package_id }}'
+          title: '[${{ inputs.ext_type }} Update] ${{ inputs.package_id }} => ${{ inputs.commit_ref }}'
           body: |
             ## ${{ inputs.ext_type }} Update
             

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -23,19 +23,8 @@ on:
         type: string
 
 permissions:
-  actions: read
-  checks: read
   contents: read
-  deployments: read
-  id-token: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
   pull-requests: write
-  repository-projects: read
-  security-events: read
-  statuses: read
   
 jobs:
   pull_submodule:

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -32,7 +32,7 @@ permissions:
   discussions: read
   packages: read
   pages: read
-  pull-requests: read|write
+  pull-requests: write
   repository-projects: read
   security-events: read
   statuses: read

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -22,8 +22,20 @@ on:
         required: true
         type: string
 
-permissions: read-all
-
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  deployments: read
+  id-token: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read|write
+  repository-projects: read
+  security-events: read
+  statuses: read
   
 jobs:
   pull_submodule:
@@ -65,7 +77,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update ${{ inputs.ext_type }} - ${{ inputs.package_id }}
           title: '[${{ inputs.ext_type }} Update] ${{ inputs.package_id }}'
           body: |

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -33,12 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
-      - name: Set Upstream
-        run: |
-          git remote add upstream https://github.com/Macro-Deck-org/Macro-Deck-Extensions.git
-          git fetch upstream main
-          git branch --set-upstream-to upstream/main
-      
       - name: Get Output Path
         id: ext_type_check
         run: |

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with: 
+          repository: Macro-Deck-org/Macro-Deck-Extensions
       
       - name: Get Output Path
         id: ext_type_check

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -32,8 +32,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with: 
-          repository: Macro-Deck-org/Macro-Deck-Extensions
+      
+      - name: Set Upstream
+        run: |
+          git remote add upstream git@github.com:Macro-Deck-org/Macro-Deck-Extensions.git
+          git fetch upstream main
+          git branch --set-upstream-to upstream/main
       
       - name: Get Output Path
         id: ext_type_check

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -23,7 +23,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   
 jobs:

--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ All artifacts to include in Macro Deck must be pulled into this repository for b
 ### How to publish your content
 
 #### Workflow Process (**RECOMMENDED**)
-1. Click on the `Actions` tab
-2. Click on the `Add/Update Extension` workflow
+1. Fork this repository
+2. On your fork, click on the `Actions` tab
+3. Click on the `Add/Update Extension` workflow
 
    > **Note:** if on mobile click the `Select workflow` button first
    
-3. Click on `Run workflow` button
-4. Fill in the details and click the green `Run workflow` button under the fields
+4. Click on `Run workflow` button
+5. Fill in the details and click the green `Run workflow` button under the fields
+6. Open the PR that is created, accept and merge it
+7. On your main branch, create a PR to the parent repository
+  - This is required due to permissions via actions being more strict than the web UI
 
 #### Manual Process
 > **Note:** This is the old process and **you should use the workflow process above**. This is kept here for documentation purposes only.


### PR DESCRIPTION
Fixes the PR workflow. Permissions were readjusted to write since this will run on a fork only now.

README.md updated with the new instructions for use. Two PRs will be required. One on the fork to pull the submodule changes that merges into main. And then a second manual PR will be required to send that to the main repository.