### PR TITLE
Adds Sanity Check for Worklow

### DIFF
--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -81,8 +81,8 @@ jobs:
             fi
 
             # csproj check
-            old_version=$(git cat-file -p ${{ env.current_hash }}:*.csproj | jq '[.version][0]')
-            new_version=$(git cat-file -p HEAD:*.csproj | jq '[.version][0]')
+            old_version=$(git cat-file -p ${{ env.current_hash }}:*.csproj | grep -oPm1 "(?<=<Version>)[^<]+"
+            new_version=$(git cat-file -p HEAD:*.csproj | grep -oPm1 "(?<=<Version>)[^<]+"
             if [ $old_version == $new_version ]; then
               echo "::error::csproj file 'version' node was not updated"
               result=1
@@ -93,7 +93,7 @@ jobs:
             fi
           else
             git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]' || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
-            git cat-file -p HEAD:*.csproj | jq '[.version][0]' || echo "::error::C# project file 'version' key does not exist" && exit 1
+            git cat-file -p HEAD:*.csproj | grep -oPm1 "(?<=<Version>)[^<]+" || echo "::error::C# project file 'version' key does not exist" && exit 1
           fi
           cd ../..
           

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -70,12 +70,30 @@ jobs:
         run: |
           cd "./${{ env.output_path }}/${{ inputs.package_id }}"
           if [ ! -z "${{ env.current_hash }}" ]; then
-            git diff ${{ env.current_hash }}..HEAD
-            git diff ${{ env.current_hash }}..HEAD "ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
-            git diff ${{ env.current_hash }}..HEAD "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
+            result=0
+            
+            # ExtensionManifest.json check
+            old_version=$(git cat-file -p ${{ env.current_hash }}:ExtensionManifest.json | jq '[.version][0]')
+            new_version=$(git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]')
+            if [ $old_version == $new_version ]; then
+              echo "::error::ExtensionManifest.json 'version' key was not updated"
+              result=1
+            fi
+
+            # csproj check
+            old_version=$(git cat-file -p ${{ env.current_hash }}:*.csproj | jq '[.version][0]')
+            new_version=$(git cat-file -p HEAD:*.csproj | jq '[.version][0]')
+            if [ $old_version == $new_version ]; then
+              echo "::error::csproj file 'version' node was not updated"
+              result=1
+            fi
+
+            if [ result -ne 0 ]; then
+              exit 1;
+            fi
           else
-            git grep '"version"' -- "ExtensionManifest.json" || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
-            git grep "<Version>" -- "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" || echo "::error::C# project file 'version' key does not exist" && exit 1
+            git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]' || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
+            git cat-file -p HEAD:*.csproj | jq '[.version][0]' || echo "::error::C# project file 'version' key does not exist" && exit 1
           fi
           cd ../..
           

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -65,8 +65,8 @@ jobs:
           
       - name: Sanity Check
         run: |
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated"
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::The C# project file 'version' node was not updated"
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::The C# project file 'version' node was not updated" && exit 1
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -93,7 +93,7 @@ jobs:
             fi
           else
             git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]' || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
-            git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+" || echo "::error::C# project file 'version' key does not exist" && exit 1
+            git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+" || echo "::error::.csproj project file 'version' key does not exist" && exit 1
           fi
           cd ../..
           

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -65,9 +65,11 @@ jobs:
           
       - name: Sanity Check
         run: |
+          cd "./${{ env.output_path }}/${{ inputs.package_id }}"
           git diff
           git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
           git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
+          cd ../..
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -65,8 +65,8 @@ jobs:
           
       - name: Sanity Check
         run: |
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || true
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || true
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version"
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>"
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -80,17 +80,20 @@ jobs:
               result=1
             fi
 
-            # csproj check
-            old_csproj_version=$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
-            new_csproj_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
-            if [ $old_csproj_version == $new_csproj_version ]; then
-              echo "::error::csproj file 'version' node was not updated"
-              result=1
-            fi
-            
-            if [ ! -z $new_manifest_version ] && [ ! -z $new_csproj_version ] && [ $new_manifest_version != $new_csproj_version ]; then
-              echo "::error::ExtensionManifest.json 'version' token does not match the csproj file's 'Version' node"
-              result=1
+            if [ ${{ inputs.ext_type }} = 'Plugin' ]; then 
+              # csproj check
+              old_csproj_version=$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
+              new_csproj_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
+              if [ $old_csproj_version == $new_csproj_version ]; then
+                echo "::error::csproj file 'version' node was not updated"
+                result=1
+              fi
+
+              # ExntensionManifest <-> csproj check
+              if [ ! -z $new_manifest_version ] && [ ! -z $new_csproj_version ] && [ $new_manifest_version != $new_csproj_version ]; then
+                echo "::error::ExtensionManifest.json 'version' token does not match the csproj file's 'Version' node"
+                result=1
+              fi
             fi
 
             if [ $result -ne 0 ]; then
@@ -106,16 +109,19 @@ jobs:
               result=1
             fi
             
-            # csproj check
-            csproj_version="$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")"
-            if [ -z csproj_version ]; then
-              echo "::error::csproj file 'version' key does not exist"
-              result=1
-            fi
-            
-            if [ ! -z $manifest_version ] && [ ! -z $csproj_version ] && [ $manifest_version != $csproj_version ]; then
-              echo "::error::ExtensionManifest.json 'version' token does not match the csproj file's 'Version' node"
-              result=1
+            if [ ${{ inputs.ext_type }} = 'Plugin' ]; then 
+              # csproj check
+              csproj_version="$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")"
+              if [ -z csproj_version ]; then
+                echo "::error::csproj file 'version' key does not exist"
+                result=1
+              fi
+
+              # ExntensionManifest <-> csproj check
+              if [ ! -z $manifest_version ] && [ ! -z $csproj_version ] && [ $manifest_version != $csproj_version ]; then
+                echo "::error::ExtensionManifest.json 'version' token does not match the csproj file's 'Version' node"
+                result=1
+              fi
             fi
             
             if [ $result -ne 0 ]; then

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -56,7 +56,7 @@ jobs:
           if [ ! -d "./${{ env.output_path }}/${{ inputs.package_id }}" ]; then
             git submodule add "${{ inputs.github_http_url }}" "./${{ env.output_path }}/${{ inputs.package_id }}"
           else
-            cd "./${{ env.output_path }}/${{ inputs.package_id }}" && git rev-parse HEAD | echo "::set-output name=current_hash::$(</dev/stdin)"
+            git --git-dir "./${{ env.output_path }}/${{ inputs.package_id }}/.git" rev-parse HEAD | echo "::set-output name=current_hash::$(</dev/stdin)"
           fi
           
       - name: Update Submodule

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -65,8 +65,13 @@ jobs:
           
       - name: Sanity Check
         run: |
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::The C# project file 'version' node was not updated" && exit 1
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version"
+          extManifest=$?
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>"
+          csProject=$?
+          if [ extManifest -ne 0 | csProject -ne 0]; then 
+            echo "::error::ExtensionManifest.json or C# project file 'version' key was not updated" && exit 1
+          fi
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -89,11 +89,28 @@ jobs:
             fi
 
             if [ $result -ne 0 ]; then
-              exit 1;
+              exit 1
             fi
           else
-            git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]' || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
-            git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+" || echo "::error::.csproj project file 'version' key does not exist" && exit 1
+            result=0
+          
+            # Manifest check
+            manifest_version=$(git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]')
+            if [ -z manifest_version ]; then 
+              echo "::error::ExtensionManifest.json 'version' key does not exist"
+              result=1
+            fi
+            
+            # csproj check
+            csproj_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
+            if [ -z csproj_version ]; then
+              echo "::error::csproj file 'version' key does not exist"
+              result=1
+            fi
+            
+            if [ $result -ne 0 ]; then
+              exit 1
+            fi
           fi
           cd ../..
           

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -73,16 +73,16 @@ jobs:
             result=0
             
             # ExtensionManifest.json check
-            old_manifest_version="$(git cat-file -p ${{ env.current_hash }}:ExtensionManifest.json | jq '[.version][0]')"
-            new_manifest_version="$(git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]')"
+            old_manifest_version=$(git cat-file -p ${{ env.current_hash }}:ExtensionManifest.json | jq -r '[.version][0]')
+            new_manifest_version=$(git cat-file -p HEAD:ExtensionManifest.json | jq -r '[.version][0]')
             if [ $old_manifest_version == $new_manifest_version ]; then
               echo "::error::ExtensionManifest.json 'version' key was not updated"
               result=1
             fi
 
             # csproj check
-            old_csproj_version="$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")"
-            new_csproj_version="$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")"
+            old_csproj_version=$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
+            new_csproj_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
             if [ $old_csproj_version == $new_csproj_version ]; then
               echo "::error::csproj file 'version' node was not updated"
               result=1
@@ -100,7 +100,7 @@ jobs:
             result=0
           
             # Manifest check
-            manifest_version="$(git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]')"
+            manifest_version="$(git cat-file -p HEAD:ExtensionManifest.json | jq -r '[.version][0]')"
             if [ -z manifest_version ]; then 
               echo "::error::ExtensionManifest.json 'version' key does not exist"
               result=1

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -51,9 +51,12 @@ jobs:
           git submodule update --init --recursive
           
       - name: Add Submodule (If Needed)
+        id: add_submodule
         run: | 
           if [ ! -d "./${{ env.output_path }}/${{ inputs.package_id }}" ]; then
             git submodule add "${{ inputs.github_http_url }}" "./${{ env.output_path }}/${{ inputs.package_id }}"
+          else
+            cd "./${{ env.output_path }}/${{ inputs.package_id }}" && echo "::set-output name=current_hash::$(git rev-parse HEAD)"
           fi
           
       - name: Update Submodule
@@ -66,9 +69,14 @@ jobs:
       - name: Sanity Check
         run: |
           cd "./${{ env.output_path }}/${{ inputs.package_id }}"
-          git diff
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
+          if [ ! -z "${{ steps.add_submodule.current_hash }}" ]; then
+            git diff ${{ steps.add_submodule.current_hash }}..HEAD
+            git diff ${{ steps.add_submodule.current_hash }}..HEAD "ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
+            git diff ${{ steps.add_submodule.current_hash }}..HEAD "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
+          else
+            git grep "version" -- "ExtensionManifest.json" || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
+            git grep "<Version>" -- "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" || echo "::error::C# project file 'version' key does not exist" && exit 1
+          fi
           cd ../..
           
       - name: Create Pull Request

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -81,8 +81,8 @@ jobs:
             fi
 
             # csproj check
-            old_version=$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+"
-            new_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+"
+            old_version=$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
+            new_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
             if [ $old_version == $new_version ]; then
               echo "::error::csproj file 'version' node was not updated"
               result=1

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -88,7 +88,7 @@ jobs:
               result=1
             fi
 
-            if [ result -ne 0 ]; then
+            if [ $result -ne 0 ]; then
               exit 1;
             fi
           else

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -56,7 +56,7 @@ jobs:
           if [ ! -d "./${{ env.output_path }}/${{ inputs.package_id }}" ]; then
             git submodule add "${{ inputs.github_http_url }}" "./${{ env.output_path }}/${{ inputs.package_id }}"
           else
-            cd "./${{ env.output_path }}/${{ inputs.package_id }}" && echo "::set-output name=current_hash::$(git rev-parse HEAD)"
+            cd "./${{ env.output_path }}/${{ inputs.package_id }}" && git rev-parse HEAD | echo "::set-output name=current_hash::$(</dev/stdin)"
           fi
           
       - name: Update Submodule
@@ -74,7 +74,7 @@ jobs:
             git diff ${{ steps.add_submodule.current_hash }}..HEAD "ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
             git diff ${{ steps.add_submodule.current_hash }}..HEAD "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
           else
-            git grep "version" -- "ExtensionManifest.json" || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
+            git grep '"version"' -- "ExtensionManifest.json" || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
             git grep "<Version>" -- "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" || echo "::error::C# project file 'version' key does not exist" && exit 1
           fi
           cd ../..

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -65,13 +65,8 @@ jobs:
           
       - name: Sanity Check
         run: |
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version"
-          extManifest=$?
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>"
-          csProject=$?
-          if [ extManifest -ne 0 | csProject -ne 0]; then 
-            echo "::error::ExtensionManifest.json or C# project file 'version' key was not updated" && exit 1
-          fi
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -65,8 +65,8 @@ jobs:
           
       - name: Sanity Check
         run: |
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version"
-          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>"
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated"
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::The C# project file 'version' node was not updated"
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -63,6 +63,11 @@ jobs:
           git checkout "${{ inputs.commit_ref }}"
           cd ../..
           
+      - name: Sanity Check
+        run: |
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || true
+          git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || true
+          
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -81,8 +81,8 @@ jobs:
             fi
 
             # csproj check
-            old_version=$(git cat-file -p ${{ env.current_hash }}:*.csproj | grep -oPm1 "(?<=<Version>)[^<]+"
-            new_version=$(git cat-file -p HEAD:*.csproj | grep -oPm1 "(?<=<Version>)[^<]+"
+            old_version=$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+"
+            new_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+"
             if [ $old_version == $new_version ]; then
               echo "::error::csproj file 'version' node was not updated"
               result=1
@@ -93,7 +93,7 @@ jobs:
             fi
           else
             git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]' || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
-            git cat-file -p HEAD:*.csproj | grep -oPm1 "(?<=<Version>)[^<]+" || echo "::error::C# project file 'version' key does not exist" && exit 1
+            git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+" || echo "::error::C# project file 'version' key does not exist" && exit 1
           fi
           cd ../..
           

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -56,7 +56,7 @@ jobs:
           if [ ! -d "./${{ env.output_path }}/${{ inputs.package_id }}" ]; then
             git submodule add "${{ inputs.github_http_url }}" "./${{ env.output_path }}/${{ inputs.package_id }}"
           else
-            git --git-dir "./${{ env.output_path }}/${{ inputs.package_id }}/.git" rev-parse HEAD | echo "::set-output name=current_hash::$(</dev/stdin)"
+            git --git-dir "./${{ env.output_path }}/${{ inputs.package_id }}/.git" rev-parse HEAD | echo "current_hash=$(</dev/stdin)" >> $GITHUB_ENV
           fi
           
       - name: Update Submodule
@@ -69,10 +69,10 @@ jobs:
       - name: Sanity Check
         run: |
           cd "./${{ env.output_path }}/${{ inputs.package_id }}"
-          if [ ! -z "${{ steps.add_submodule.current_hash }}" ]; then
-            git diff ${{ steps.add_submodule.current_hash }}..HEAD
-            git diff ${{ steps.add_submodule.current_hash }}..HEAD "ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
-            git diff ${{ steps.add_submodule.current_hash }}..HEAD "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
+          if [ ! -z "${{ env.CURRENT_HASH }}" ]; then
+            git diff ${{ env.CURRENT_HASH }}..HEAD
+            git diff ${{ env.CURRENT_HASH }}..HEAD "ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
+            git diff ${{ env.CURRENT_HASH }}..HEAD "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
           else
             git grep '"version"' -- "ExtensionManifest.json" || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
             git grep "<Version>" -- "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" || echo "::error::C# project file 'version' key does not exist" && exit 1

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -88,7 +88,7 @@ jobs:
               result=1
             fi
             
-            if [ $new_manifest_version != $new_csproj_version ]; then
+            if [ ! -z $new_manifest_version ] && [ ! -z $new_csproj_version ] && [ $new_manifest_version != $new_csproj_version ]; then
               echo "::error::ExtensionManifest.json 'version' token does not match the csproj file's 'Version' node"
               result=1
             fi
@@ -113,7 +113,7 @@ jobs:
               result=1
             fi
             
-            if [ $manifest_version != $csproj_version ]; then
+            if [ ! -z $manifest_version ] && [ ! -z $csproj_version ] && [ $manifest_version != $csproj_version ]; then
               echo "::error::ExtensionManifest.json 'version' token does not match the csproj file's 'Version' node"
               result=1
             fi

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -65,6 +65,7 @@ jobs:
           
       - name: Sanity Check
         run: |
+          git diff
           git diff "./${{ env.output_path }}/${{ inputs.package_id }}/ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
           git diff "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
           

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -69,10 +69,10 @@ jobs:
       - name: Sanity Check
         run: |
           cd "./${{ env.output_path }}/${{ inputs.package_id }}"
-          if [ ! -z "${{ env.CURRENT_HASH }}" ]; then
-            git diff ${{ env.CURRENT_HASH }}..HEAD
-            git diff ${{ env.CURRENT_HASH }}..HEAD "ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
-            git diff ${{ env.CURRENT_HASH }}..HEAD "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
+          if [ ! -z "${{ env.current_hash }}" ]; then
+            git diff ${{ env.current_hash }}..HEAD
+            git diff ${{ env.current_hash }}..HEAD "ExtensionManifest.json" | grep "version" || echo "::error::ExtensionManifest.json 'version' key was not updated" && exit 1
+            git diff ${{ env.current_hash }}..HEAD "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" | grep "<Version>" || echo "::error::C# project file 'version' key was not updated" && exit 1
           else
             git grep '"version"' -- "ExtensionManifest.json" || echo "::error::ExtensionManifest.json 'version' key does not exist" && exit 1
             git grep "<Version>" -- "./${{ env.output_path }}/${{ inputs.package_id }}/*.csproj" || echo "::error::C# project file 'version' key does not exist" && exit 1

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -73,18 +73,23 @@ jobs:
             result=0
             
             # ExtensionManifest.json check
-            old_version=$(git cat-file -p ${{ env.current_hash }}:ExtensionManifest.json | jq '[.version][0]')
-            new_version=$(git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]')
-            if [ $old_version == $new_version ]; then
+            old_manifest_version="$(git cat-file -p ${{ env.current_hash }}:ExtensionManifest.json | jq '[.version][0]')"
+            new_manifest_version="$(git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]')"
+            if [ $old_manifest_version == $new_manifest_version ]; then
               echo "::error::ExtensionManifest.json 'version' key was not updated"
               result=1
             fi
 
             # csproj check
-            old_version=$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
-            new_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
-            if [ $old_version == $new_version ]; then
+            old_csproj_version="$(git cat-file -p ${{ env.current_hash }}:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")"
+            new_csproj_version="$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")"
+            if [ $old_csproj_version == $new_csproj_version ]; then
               echo "::error::csproj file 'version' node was not updated"
+              result=1
+            fi
+            
+            if [ $new_manifest_version != $new_csproj_version ]; then
+              echo "::error::ExtensionManifest.json 'version' token does not match the csproj file's 'Version' node"
               result=1
             fi
 
@@ -95,16 +100,21 @@ jobs:
             result=0
           
             # Manifest check
-            manifest_version=$(git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]')
+            manifest_version="$(git cat-file -p HEAD:ExtensionManifest.json | jq '[.version][0]')"
             if [ -z manifest_version ]; then 
               echo "::error::ExtensionManifest.json 'version' key does not exist"
               result=1
             fi
             
             # csproj check
-            csproj_version=$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")
+            csproj_version="$(git cat-file -p HEAD:$(ls *.csproj | head -n 1) | grep -oPm1 "(?<=<Version>)[^<]+")"
             if [ -z csproj_version ]; then
               echo "::error::csproj file 'version' key does not exist"
+              result=1
+            fi
+            
+            if [ $manifest_version != $csproj_version ]; then
+              echo "::error::ExtensionManifest.json 'version' token does not match the csproj file's 'Version' node"
               result=1
             fi
             


### PR DESCRIPTION
The workflow to update a submodule/icon pack now performs the following sanity check

1. ExtensionManifest.json
  - For new, checks that it exists with a version token
  - For existing, checks that the version token was updated
2. *.csproj file
  - For Plugin type only
  - For new, checks that it exists with a Version node
  - For existing, checks that the Version node was updated
 
For plugin type, additionally checks that the version token from ExtensionManifest.json matches the Version node from the top .csproj file.