### PR TITLE
MacroDeck Unity plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -136,3 +136,6 @@
 [submodule "IconPacks/RecklessBoon.PoweredSteel.Arrows"]
 	path = IconPacks/RecklessBoon.PoweredSteel.Arrows
 	url = https://github.com/RecklessBoon/Macro-Deck-Icon-Powered-Steel-Arrows.git
+[submodule "Plugins/Sulbon.UDPCallUnity"]
+	path = Plugins/Sulbon.UDPCallUnity
+	url = https://github.com/sulbon/Macro-Deck-Unity-Plugin


### PR DESCRIPTION
<!--- Please fill out the following template -->

### Description
The Unity plugin adds MacroDeck Actions to control running Unity instance,  by "execute menu item" or "switch layout". 

For Unity-side, a UDP server must be active. Download unitypackage from 
[https://github.com/sulbon/Macro-Deck-Unity-Plugin/raw/main/PutInUnityEditor/MacroDeckUnityUDPServer.unitypackage](url)

Install MacroDeckUnityUDPServer.unitypackage, it contains scripts(UDP server); This extension by default uses port:8193 (MacroDeck uses 8191). To change it either open Unity menu Tools/MacroDeck/UDPExecuteEditor or just modify the code in UDPExecuteEditor.cs. The server runs auto when Unity finished compiling C#.

### On which Macro Deck Version has this been tested/created?
At least works on MacroDeck 2.12.0

### How has this been tested? (Only required for plugins)
Works on Unity 2019 LTS. Not tested on other vertions, but it uses only some common methods which I believe Unity wont update so frequent, so it may work fine on other versions. Will test if there is chance.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I used the workflow to add the Extension ([described here](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#add-your-extension-to-the-extension-store))
- [ x] I have not added any files manually to the Macro-Deck-Extensions repository
- [x ] The added Extension is tested and works
- [x ] The added Extension meets [the rules](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#rules)
- [x ] The repository of my Extension meets the [required file structure](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#repository-root-file-structure)
