### PR TITLE
New Plugin - jbcarreon123.WebNowPlayingPlugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -163,3 +163,6 @@
 [submodule "IconPacks/Pukima.Overwatch.PlayerIcons"]
 	path = IconPacks/Pukima.Overwatch.PlayerIcons
 	url = https://github.com/Pukima-MacroDeck/Icons-Overwatch-PlayerIcons
+[submodule "Plugins/jbcarreon123.WebNowPlayingPlugin"]
+	path = Plugins/jbcarreon123.WebNowPlayingPlugin
+	url = https://github.com/jbcarreon123/MacroDeck2-WebNowPlayingPlugin


### PR DESCRIPTION
<!--- Please fill out the following template -->

### Description (Only required for new plugins)
It interfaces WebNowPlaying into Macro Deck so it can replace the buggy KSoft.MediaInfo plugin on most cases
<!--- Describe what your Extension does -->

### On which Macro Deck Version has this been tested/created?
MD 2.12.0
<!--- On which version of Macro Deck have you created and tested this extension? -->

### How has this been tested? (Only required for plugins)
I tested it by building it and putting the updated plugin into Macro Deck 2.
<!--- Please describe in detail how you tested your changes -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I used the workflow to add the Extension ([described here](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#add-your-extension-to-the-extension-store))
- [x] I have not added any files manually to the Macro-Deck-Extensions repository
- [x] The added Extension is tested and works
- [x] The added Extension meets [the rules](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#rules)
- [x] The repository of my Extension meets the [required file structure](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#repository-root-file-structure)
