### PR TITLE
CI/CD Workflow Added

### DIFF
--- a/.github/workflows/compile_extension.yml
+++ b/.github/workflows/compile_extension.yml
@@ -14,6 +14,8 @@ jobs:
       matrix: ${{ steps.matrix.outputs.value }}
     
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3.3.0
     - id: matrix
       run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\"}", $1, $2)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
 

--- a/.github/workflows/compile_extension.yml
+++ b/.github/workflows/compile_extension.yml
@@ -1,28 +1,33 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
-name: .NET
+name: Build Extensions
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
-  build:
-
+  setup:
     runs-on: ubuntu-latest
-
+    outputs:
+      matrix: ${{ steps.matrix.outputs.value }}
+    
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+    - id: matrix
+      run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\"}", $1, $2)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
+
+  build:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        value: ${{fromJson(needs.setup.outputs.matrix)}}
+        
+    steps:
+    - name: Build Extension
+      uses: RecklessBoon/Macro-Deck-Extension-Build-Action@main
       with:
-        dotnet-version: 6.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+        upsert-release: 'false'
+        ext-repo: ${{ matrix.repo }}
+        ext-ref: ${{ matrix.ref }}

--- a/.github/workflows/compile_extension.yml
+++ b/.github/workflows/compile_extension.yml
@@ -1,0 +1,28 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -50,19 +50,19 @@ jobs:
     - name: Extract Extension Info
       id: extension_info
       run: |
-        type=$(jq --raw-output '."type"' ./${{ matrix.value.path }}/ExtensionManifest.json)
+        type=$(cat ./${{ matrix.value.path }} | node -pe 'JSON.parse(fs.readFileSync(0)).type')
         if [ $type -eq 0 ]; then
           type="Plugin"
         elif [ $type -eq 1 ];then
           type="IconPack"
         fi
         echo "EXT_TYPE=$type" >> $GITHUB_OUTPUT
-        echo "EXT_NAME=$(jq --raw-output '."name"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
-        echo "EXT_AUTHOR=$(jq --raw-output '."author"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
-        echo "EXT_REPO=$(jq --raw-output '."repository"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
-        echo "EXT_PACKAGE_ID=$(jq --raw-output '."packageId"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
-        echo "EXT_VERSION=$(jq --raw-output '."version"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
-        echo "EXT_D_SUPPORT_USER_ID=$(jq '."dSupportUserId"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_NAME=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).name')" >> $GITHUB_OUTPUT
+        echo "EXT_AUTHOR=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).author')" >> $GITHUB_OUTPUT
+        echo "EXT_REPO=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).repository')" >> $GITHUB_OUTPUT
+        echo "EXT_PACKAGE_ID=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).packageId')" >> $GITHUB_OUTPUT
+        echo "EXT_VERSION=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).version')" >> $GITHUB_OUTPUT
+        echo "EXT_D_SUPPORT_USER_ID=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).dSupportUserId')" >> $GITHUB_OUTPUT
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -97,7 +97,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         curl -X 'POST' \
-        --fail
+        --fail \
         'https://extensionstore.api.macro-deck.app/Extensions' \
         -H 'accept: */*' \
         -H "Authorization: $MACRO_DECK_API_AUTH" \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -27,14 +27,14 @@ jobs:
     needs: [ setup ]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         value: ${{fromJson(needs.setup.outputs.matrix)}}
         
     steps:
     - name: Build Extension
-      continue-on-error: true
       uses: RecklessBoon/Macro-Deck-Extension-Build-Action@main
       with:
-        upsert-release: 'false'
+        upsert-release: false
         ext-repo: ${{ matrix.value.repository }}
         ext-ref: ${{ matrix.value.ref }}

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -140,5 +140,5 @@ jobs:
         steps.upload-build-files.outputs.http_code < 200 || 
         steps.upload-build-files.outputs.http_code >= 300
       run: |
-        echo "::error ::Failed to upload files to build server. Response: ${{ steps.upload-build-files.outputs.response }}"
+        echo "::error ::Failed to upload files to build server. HTTP Code: ${{ steps.upload-build-files.outputs.http_code }} Response: ${{ steps.upload-build-files.outputs.response }}"
         exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -26,9 +26,8 @@ jobs:
   build:
     needs: [ setup ]
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         value: ${{fromJson(needs.setup.outputs.matrix)}}
         
@@ -119,12 +118,20 @@ jobs:
         name: ${{ steps.build_extension.outputs.artifact-name }}
     
     - name: Upload built files
+      id: upload-build-files
       env:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
-        curl -X 'POST' \
+        response=$(curl -X 'POST' \
           'https://extensionstore.api.macro-deck.app/ExtensionsFiles/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
-          -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed'
+          -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed')
+        echo "response=$response" >> $GITHUB_OUTPUT
+        
+    - name: Check upload response
+      if: fromJSON(steps.upload-build-files.outputs.response).type != ''
+      run: |
+        echo "::error ::Failed to upload files to build server. Resonse: ${{ steps.upload-build-files.outputs.response }}"
+        exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -124,13 +124,13 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         http_code=$(curl -X POST \
-          --silent --output /dev/null --write-out '%{http_code}' \
+          --silent --output './upload-build-files.${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}.log' --write-out '%{http_code}' \
           'https://extensionstore.api.macro-deck.app/ExtensionsFiles/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed')
-        response=$?
+        response="$(cat './upload-build-files.${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}.log')"
         echo "Upload response code: $http_code"
         echo "http_code=$http_code" >> $GITHUB_OUTPUT
         echo "response=$response" >> $GITHUB_OUTPUT

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -48,7 +48,7 @@ jobs:
         ext-ref: ${{ matrix.value.ref }}
         
     - name: Extract Extension Info
-      run: cat <(echo -n "manifest=") "${{ matrix.value.path }}/ExtensionManifest.json" >> $GITHUB_ENV
+      run: cat "${{ matrix.value.path }}/ExtensionManifest.json" | echo "manifest=$(cat -)" >> $GITHUB_ENV
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -124,7 +124,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         http_code=$(curl \
-          --silent --output /dev/null --write-out %{http_code} \          
+          --silent --output /dev/null --write-out '%{http_code}' \          
           -X 'POST' \
           'https://extensionstore.api.macro-deck.app/ExtensionsFiles/Upload' \
           -H 'accept: */*' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -127,4 +127,4 @@ jobs:
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
-          -F 'file=@${{ steps.build_extension.outputs.artifact-name }};type=application/x-zip-compressed'
+          -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -91,12 +91,13 @@ jobs:
       env:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
-        response=$(curl --fail-with-body -X POST \
+        curl --fail-with-body -o "./${{ fromJSON(env.manifest).packageId }}-upload-response.json" -X POST \
           '${{ vars.EXTENSION_STORE_API_URL }}/extensions/files/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
-          -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed')
+          -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed' || true)
+        response=$(cat ${{ fromJSON(env.manifest).packageId }})
         echo -e "Response:\n$response"
         echo "response=$response" >> $GITHUB_OUTPUT
         

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -111,3 +111,20 @@ jobs:
           "dSupportUserId": "${{ steps.extension_info.outputs.EXT_SUPPORT_DISCORD_USER_ID }}",
           "downloads": 0
         }'
+        
+    - name: Download a Build Artifact
+      uses: actions/download-artifact@v3.0.2
+      with:
+        # Artifact name
+        name: ${{ steps.build_extension.outputs.artifact-name }}
+    
+    - name: Upload built files
+      env:
+        MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
+      run: |
+        curl -X 'POST' \
+          'https://extensionstore.api.macro-deck.app/ExtensionsFiles/Upload' \
+          -H 'accept: */*' \
+          -H "Authorization: $MACRO_DECK_API_AUTH" \
+          -H 'Content-Type: multipart/form-data' \
+          -F 'file=@${{ steps.build_extension.outputs.artifact-name }};type=application/x-zip-compressed'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -177,7 +177,7 @@ jobs:
                 "name" : "${{ env.release && 'Release' || 'Commit' }}",
                 "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
                 "inline" : false
-              }${{ env.release && format(',{ ''name''': ''Changelog''', ''value''': ''{0}'', ''inline''': false }', fromJSON(env.release).body) }}
+              }${{ env.release && format(',{ ''name'': ''Changelog'', ''value'': ''{0}'', ''inline'': false }', fromJSON(env.release).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -32,6 +32,7 @@ jobs:
         
     steps:
     - name: Build Extension
+      continue-on-error: true
       uses: RecklessBoon/Macro-Deck-Extension-Build-Action@main
       with:
         upsert-release: 'false'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -94,11 +94,13 @@ jobs:
         
     - name: Create new Extension
       if: fromJSON(steps.check-if-new.outputs.is_new) == 1
+      env:
+        MACRO_DECK_API_TOKEN: ${{ secrets.MACRO_DECK_API_TOKEN }}
       run: |
         curl -X 'POST' \
         'https://extensionstore.api.macro-deck.app/Extensions' \
         -H 'accept: */*' \
-        -H 'Authentication: Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}' \
+        -H 'Authentication: Bearer $MACRO_DECK_API_TOKEN' \
         -H 'Content-Type: application/json' \
         -d '{
           "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Check if new
       id: check-if-new
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --fail --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 404 ]; then
           is_new=1
@@ -97,6 +97,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         curl -X 'POST' \
+        --fail
         'https://extensionstore.api.macro-deck.app/Extensions' \
         -H 'accept: */*' \
         -H "Authorization: $MACRO_DECK_API_AUTH" \
@@ -122,17 +123,23 @@ jobs:
       env:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
-        response=$(curl -X 'POST' \
+        http_code=$(curl \
+          --fail --silent --output /dev/null --write-out %{http_code} \          
+          -X 'POST' \
           'https://extensionstore.api.macro-deck.app/ExtensionsFiles/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed')
-        echo "$response"
+        response=$?
+        echo "Upload response code: $http_code"
+        echo "http_code=$http_code" >> $GITHUB_OUTPUT
         echo "response=$response" >> $GITHUB_OUTPUT
         
     - name: Check upload response
-      if: steps.upload-build-files.outputs.response != '' && fromJSON(steps.upload-build-files.outputs.response).status != ''
+      if: |
+        steps.upload-build-files.outputs.http_code < 200 || 
+        steps.upload-build-files.outputs.http_code >= 300
       run: |
-        echo "::error ::Failed to upload files to build server. Resonse: ${{ steps.upload-build-files.outputs.response }}"
+        echo "::error ::Failed to upload files to build server. Response: ${{ steps.upload-build-files.outputs.response }}"
         exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -97,13 +97,13 @@ jobs:
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed' || true
-        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json" | tr -d '\n')
+        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json")
         echo -e "Response:\n$response"
-        echo "response=$response" >> $GITHUB_OUTPUT
+        echo "response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json")" >> $GITHUB_OUTPUT
         
     - name: Check upload response
       if: |
-        fromJSON(steps.upload-build-files.outputs.response).success == 'false' &&
+        fromJSON(steps.upload-build-files.outputs.response).success == false &&
         fromJSON(steps.upload-build-files.outputs.response).errorCode != 4
       run: |
         echo "::error ::Failed to upload files to build server. Response: ${{ steps.upload-build-files.outputs.response }}" && exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
     - name: Build Extension
       id: build_extension
+      continue-on-error: true
       uses: RecklessBoon/Macro-Deck-Extension-Build-Action@main
       with:
         upsert-release: false

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -103,9 +103,8 @@ jobs:
       env:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
-        response=$(curl -X POST \
+        response=$(curl --fail-with-body -X POST \
           '${{ vars.EXTENSION_STORE_API_URL }}/ExtensionsFiles/Upload' \
-          --fail-with-body \ 
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         delim="EOF-${RANDOM}"
         echo "manifest<<${delim}" >> $GITHUB_ENV
-        cat "${{ matrix.value.path }}/ExtensionManifest.json" | xargs printf "%s" >> $GITHUB_ENV
+        cat "${{ matrix.value.path }}/ExtensionManifest.json" | perl -pe 'chome if eof' >> $GITHUB_ENV
         echo -e "\n${delim}" >> $GITHUB_ENV
     
     - name: Debug Extension Info

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -52,7 +52,7 @@ jobs:
         tag=$(git tag --contains "${{ matrix.value.ref }}" | head -n 1)
         if [ -n "$tag" ]; then
           echo "Tag $tag found for commit $ref. Now looking for release..."
-          release_body=$(gh release view $tag --json body)
+          release_body=$(gh release view $tag --json body || true)
         fi
         echo "release=$release" >> $GITHUB_ENV
       

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Check if new
       id: check-if-new
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' '${EXTENSION_STORE_API_URL}/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' '${{ vars.EXTENSION_STORE_API_URL }}/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 404 ]; then
           is_new=1
@@ -104,7 +104,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         response=$(curl -X POST \
-          '${EXTENSION_STORE_API_URL}/ExtensionsFiles/Upload' \
+          '${{ vars.EXTENSION_STORE_API_URL }}/ExtensionsFiles/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     needs: [ setup ]
     runs-on: ubuntu-latest
+    environment: development
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         delim="EOF-${RANDOM}"
         echo "manifest<<${delim}" >> $GITHUB_ENV
-        cat "${{ matrix.value.path }}/ExtensionManifest.json" | awk '{$1=$1};NF' >> $GITHUB_ENV
+        cat "${{ matrix.value.path }}/ExtensionManifest.json" | xargs printf "%s" >> $GITHUB_ENV
         echo -e "\n${delim}" >> $GITHUB_ENV
     
     - name: Debug Extension Info

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -42,6 +42,17 @@ jobs:
       
     - name: Init Submodule
       run: git submodule update --init --recursive ${{ matrix.value.path }}
+
+    - name: Get Release for Commit
+      working-directory: ${{ matrix.value.path }}
+      run: |
+        git fetch --all --tags --prune
+        tag=$(git tag --contains "${{ matrix.value.ref }}" | head -n 1)
+        if [ -z "$tag" ]; then
+          echo "Tag $tag found for commit $ref. Now looking for release..."
+          release=$(gh release view $tag --json body)
+        fi
+        echo "release=$release" >> $GITHUB_ENV
       
     - name: Build Extension
       id: build_extension
@@ -134,7 +145,7 @@ jobs:
                 "name" : "SHA",
                 "value" : "${{ matrix.value.ref }}" , 
                 "inline" : false
-              }
+              },${{ env.response && format('{ "name": "Changelog", "value": "%s", "inlinde": false }', fromJSON(env.response).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -48,7 +48,9 @@ jobs:
         ext-ref: ${{ matrix.value.ref }}
         
     - name: Extract Extension Info
-      run: cat "${{ matrix.value.path }}/ExtensionManifest.json" | tr '\n' ' ' | echo "manifest=$(cat -)" >> $GITHUB_ENV
+      run: |
+        json=$(cat "${{ matrix.value.path }}/ExtensionManifest.json" | tr '\n' ' ')
+        echo "manifest=$json" >> $GITHUB_ENV
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -83,7 +83,7 @@ jobs:
       run:  |
         http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
         is_new=0
-        if [ $(($http_code)) -eq 200 ]; then
+        if [ $(($http_code)) -eq 404 ]; then
           is_new=1
         fi
         echo "is_new=$is_new" >> $GITHUB_OUTPUT

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -89,7 +89,7 @@ jobs:
         echo "is_new=$is_new" >> $GITHUB_OUTPUT
         
     - name: Create new Extension
-      if: steps.check-if-new.outputs.is_new == '1'
+      if: fromJSON(steps.check-if-new.outputs.is_new) == 1
       run: |
         curl -X 'POST' \
         'https://extensionstore.api.macro-deck.app/Extensions' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -22,6 +22,8 @@ jobs:
       
     - name: Generate Matrix
       id: matrix
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         pr_paths=$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path' || true)
         git submodule --quiet foreach "

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -73,6 +73,9 @@ jobs:
           echo "Tag $tag found for commit $ref. Now looking for release..."
           release_body=$(gh release view $tag --json body,name || true)
         fi
+        if [ -n "$release" ]; then
+          echo "Release found! $release"
+        fi
         echo "release=$release" >> $GITHUB_ENV
       
     - name: Build Extension

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -145,7 +145,7 @@ jobs:
                 "name" : "SHA",
                 "value" : "${{ matrix.value.ref }}" , 
                 "inline" : false
-              },${{ env.response && format('{ "name": "Changelog", "value": "%s", "inlinde": false }', fromJSON(env.response).body) }}
+              }${{ env.response && format(',{ "name": "Changelog", "value": "%s", "inline": false }', fromJSON(env.response).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -71,4 +71,4 @@ jobs:
     
     - name: Show artifact output
       shell: bash
-      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result) }}"
+      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result)[matrix.value.respository] }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -50,16 +50,38 @@ jobs:
     - name: Extract Extension Info
       id: extension_info
       run: |
-        echo "EXT_VERSION=$(jq --raw-output '."version"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
         echo "EXT_TYPE=$(jq --raw-output '."type"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_NAME=$(jq --raw-output '."name"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_AUTHOR=$(jq --raw-output '."author"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_REPO=$(jq --raw-output '."repository"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
         echo "EXT_PACKAGE_ID=$(jq --raw-output '."packageId"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
-        echo "EXT_TARGET_API_VERSION=$(jq '."target-plugin-api-version"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_VERSION=$(jq --raw-output '."version"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_D_SUPPORT_USER_ID=$(jq '."dSupportUserId"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+  
+    - name: Validate Extension Info
+      if: |
+        steps.extension_info.outputs.EXT_TYPE == '' || 
+        steps.extension_info.outputs.EXT_NAME == '' || 
+        steps.extension_info.outputs.EXT_AUTHOR == '' || 
+        steps.extension_info.outputs.EXT_REPO == '' || 
+        steps.extension_info.outputs.EXT_PACKAGE_ID == '' || 
+        steps.extension_info.outputs.EXT_VERSION == ''
+      shell: bash
+      run: |
+        echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"
+        echo "[Extension Info Values]"
+        echo "Type                     : ${{ steps.extension_info.outputs.EXT_TYPE }}"
+        echo "Name                     : ${{ steps.extension_info.outputs.EXT_NAME }}"
+        echo "Author                   : ${{ steps.extension_info.outputs.EXT_AUTHOR }}"
+        echo "GitHub Repository        : ${{ steps.extension_info.outputs.EXT_REPO }}"
+        echo "Package ID               : ${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}"
+        echo "Version                  : ${{ steps.extension_info.outputs.EXT_VERSION }}"
+        exit 1
   
     - name: Check if new
       id: check-if-new
-      if: steps.extension_info.outputs.EXT_TYPE == 'Plugin'
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions/${{ matrix.value.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions/${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || 'Icon/' }}${{ matrix.value.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 200 ]; then
           is_new=1
@@ -68,5 +90,18 @@ jobs:
         
     - name: Create new Extension
       if: steps.check-if-new.outputs.is_new == '1'
-      run: echo "Need to create the extension"
-      
+      run: |
+        curl -X 'POST' \
+        'https://extensionstore.api.macro-deck.app/Extensions' \
+        -H 'accept: */*' \
+        -H 'Authentication: Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}' \
+        -H 'Content-Type: application/json' \
+        -d '{
+          "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",
+          "extensionType": ${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && 0 || 1 }},
+          "name": "${{ steps.extension_info.outputs.EXT_NAME }}",
+          "author": "${{ steps.extension_info.outputs.EXT_AUTHOR }}",
+          "gitHubRepository": "${{ steps.extension_info.outputs.EXT_REPO }}",
+          "dSupportUserId": "${{ steps.extension_info.outputs.EXT_SUPPORT_DISCORD_USER_ID }}",
+          "downloads": 0
+        }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -181,7 +181,7 @@ jobs:
                 "name" : "${{ env.release && 'Release' || 'Commit' }}",
                 "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
                 "inline" : false
-              }${{ env.release && fromJSON(env.release).body) && format(',{{ "name": "Changelog", "value": "{0}", "inline": false }}', fromJSON(env.release).body) }}
+              }${{ env.release && fromJSON(env.release).body && format(',{{ "name": "Changelog", "value": "{0}", "inline": false }}', fromJSON(env.release).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -112,6 +112,7 @@ jobs:
         echo "::error ::Failed to upload files to build server. Response: ${{ steps.upload-build-files.outputs.response }}" && exit 1
 
     - name: Notify Macro Bot
+      id: notify-macro-bot
       if: fromJSON(steps.upload-build-files.outputs.response).success == true
       env:
         BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
@@ -148,5 +149,8 @@ jobs:
                 }${{ github.event_name == 'pull_request' && format(', {"name": "PR Body", "value": "{0}", "inline": false }', github.event.pull_request.body) || '' }}
               ]
             }
-          }'
+          }' || true
+        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json")
+        echo -e "Response:\n$response"
+        echo "response=$response" >> $GITHUB_OUTPUT
             

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -99,7 +99,7 @@ jobs:
       run: |
         curl -X 'POST' \
         'https://extensionstore.api.macro-deck.app/Extensions' \
-        -H 'accept: */*' \
+        -H 'accept: application/json' \
         -H 'Authorization: Bearer $MACRO_DECK_API_TOKEN' \
         -H 'Content-Type: application/json' \
         -d '{

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -73,4 +73,4 @@ jobs:
     
     - name: Show artifact output
       shell: bash
-      run: echo "Artifact name = ${{ steps.artifact-names.outputs.result[matrix..value.repository] }}"
+      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result)[matrix..value.repository] }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -16,10 +16,28 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3.3.0
+      
     - name: Init Submodules
       run: git submodule update --init --recursive --checkout
-    - id: matrix
-      run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1 $displaypath' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\",\"path\":\"%s\"}", $1, $2, $3)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
+      
+    - name: Generate Matrix
+      id: matrix
+      run: |
+        pr_paths=$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path' || true)
+        git submodule --quiet foreach "
+          paths=\"$pr_paths\"
+          if [ -z \$paths ]; then
+            paths=\"\$displaypath\"
+          fi
+          case \$displaypath in 
+            \$paths)
+              echo \$(git remote get-url origin | sed 's/https:\/\/github\.com\///' | sed 's/\.git//') \$sha1 \$displaypath | \\
+                awk 'NR > 1 {printf(\",\")} {printf(\"{\\\"repository\\\":\\\"%s\\\",\\\"ref\\\":\\\"%s\\\",\\\"path\\\":\\\"%s\\\"}\", \$1, \$2, \$3)}'
+              ;;
+          esac
+        " | cat <(echo -n 'value=[') - <(echo -n ']') 
+        git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1 $displaypath' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\",\"path\":\"%s\"}", $1, $2, $3)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
+      
     - name: Check matrix value
       run: echo "${{ steps.matrix.outputs.value }}"
 

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -123,23 +123,18 @@ jobs:
               "g":1,
               "b":1
             },
-            "title": "${{ github.event_name == 'pull_request' && github.event.pull_request.title || 'Plugin Deployed to Extension Store' }}",
+            "title": "${{ matrix.value.path }} Deployed to Extension Store",
             "fields" : [
               {
-                "name": "Path",
-                "value": "${{ matrix.value.path }}",
-                "inline": false
-              },
-              {
                 "name": "Repository URL",
-                "value": "${{ matrix.value.repository }}",
+                "value": "https://github.com/${{ matrix.value.repository }}",
                 "inline": false
               },
               {
                 "name" : "SHA",
                 "value" : "${{ matrix.value.ref }}" , 
                 "inline" : false
-              }${{ github.event_name == 'pull_request' && format(', {{"name": "PR Body", "value": "{0}", "inline": false }}', github.event.pull_request.body) || '' }}
+              }
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -149,35 +149,37 @@ jobs:
       if: fromJSON(steps.upload-build-files.outputs.response).success == true
       env:
         BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
+        CURR_VER: ${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}
+        NEW_VER: ${{ fromJSON(steps.upload-build-files.outputs.response).newVersion }}
       run: |
-        payload='{
-          "toEveryone" : false,
-          "embed" : {
-            "color" : {
-              "r":0,
-              "g":1,
-              "b":1
+        payload="{
+          'toEveryone' : false,
+          'embed' : {
+            'color' : {
+              'r':0,
+              'g':1,
+              'b':1
             },
-            "title": "${{ fromJSON(env.manifest).name }}",
-            "fields" : [
+            'title': '${{ fromJSON(env.manifest).name }}'',
+            'fields' : [
               {
-                "name": "Version",
-                "value": "${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion != fromJSON(steps.upload-build-files.outputs.response).newVersion}} && format(' -> %s', fromJSON(steps.upload-build-files.outputs.response).newVersion) || '' }}",
-                "inline": false
+                'name': 'Version',
+                'value': '$CURR_VER ${{ env.CURR_VER != env.NEW_VER && format(' -> %s', env.NEW_VER) }}',
+                'inline': false
               },
               {
-                "name": "Repository URL",
-                "value": "https://github.com/${{ matrix.value.repository }}",
-                "inline": false
+                'name': 'Repository URL',
+                'value': 'https://github.com/${{ matrix.value.repository }}',
+                'inline': false
               },
               {
-                "name" : "${{ env.release && 'Release' || 'Commit' }}",
-                "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
-                "inline" : false
+                'name' : '${{ env.release && 'Release' || 'Commit' }}',
+                'value' : '${{ env.release && fromJSON(env.release).name || matrix.value.ref }}' , 
+                'inline' : false
               }${{ env.release && format(',{ "name": "Changelog", "value": "%s", "inline": false }', fromJSON(env.release).body) }}
             ]
           }
-        }'
+        }"
         curl --fail-with-body -o "./${{ fromJSON(env.manifest).packageId }}-bot-notify-response.json" -X POST \
           '${{ vars.BOT_API_URL }}/webhook/${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && 'newextension' || 'updateextension' }}' \
           -H 'accept: */*' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -49,8 +49,11 @@ jobs:
         
     - name: Extract Extension Info
       run: |
-        json=$(cat "${{ matrix.value.path }}/ExtensionManifest.json" | tr '\n' ' ')
-        echo "manifest=$json" >> $GITHUB_ENV
+        json=$(cat "${{ matrix.value.path }}/ExtensionManifest.json")
+        echo "$json"
+        echo "manifest<<EOF" >> $GITHUB_ENV
+        echo "$json" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -125,7 +125,7 @@ jobs:
               "g":1,
               "b":1
             },
-            "title": "${{ github.event_name == 'pull_request' && github.event.pull_request.title || 'Plugin Deployed to Extension Store' }}"
+            "title": "${{ github.event_name == 'pull_request' && github.event.pull_request.title || 'Plugin Deployed to Extension Store' }}",
             "fields" : [
               {
                 "name": "Path",
@@ -150,12 +150,5 @@ jobs:
           -H 'accept: */*' \
           -H "Authorization: $BOT_API_AUTH" \
           -H 'Content-Type: application/json' \
-          -d "$payload" || true
-        failed=$?
-        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-bot-notify-response.json")
-        echo -e "Response:\n$response"
-        if [ $failed -ne 0 ]; then 
-          exit 1; 
-        fi
-        echo "response=$response" >> $GITHUB_OUTPUT
+          -d "$payload" || cat "./${{ fromJSON(env.manifest).packageId }}-bot-notify-response.json"
             

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -177,7 +177,7 @@ jobs:
                 "name" : "${{ env.release && 'Release' || 'Commit' }}",
                 "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
                 "inline" : false
-              }${{ env.release && format(',{{ ''name'': ''Changelog'', ''value'': ''{0}'', ''inline'': false }}', fromJSON(env.release).body) }}
+              }${{ env.release && format(',{{ "name: "Changelog", "value": "{0}", "inline": false }}', fromJSON(env.release).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -44,6 +44,8 @@ jobs:
       run: git submodule update --init --recursive ${{ matrix.value.path }}
 
     - name: Get Release for Commit
+      env:
+        GH_TOKEN: ${{ github.token }}
       working-directory: ${{ matrix.value.path }}
       run: |
         git fetch --all --tags --prune

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -151,10 +151,10 @@ jobs:
         steps.upload-build-files.outputs.response && 
         fromJSON(steps.upload-build-files.outputs.response).success == true
       env:
-        BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
-        currVer: ${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}
-        newVer: ${{ fromJSON(steps.upload-build-files.outputs.response).newVersion }}
-        extType: ${{ fromJSON(steps.upload-build-files.outputs.response).extensionManifest.type }}
+        BOT_API_AUTH: "Bearer ${{ steps.upload-build-files.outputs.response && fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
+        currVer: ${{ steps.upload-build-files.outputs.response && fromJSON(steps.upload-build-files.outputs.response).currentVersion }}
+        newVer: ${{ steps.upload-build-files.outputs.response && fromJSON(steps.upload-build-files.outputs.response).newVersion }}
+        extType: ${{ steps.upload-build-files.outputs.response && fromJSON(steps.upload-build-files.outputs.response).extensionManifest.type }}
       run: |
         payload='{
           "toEveryone" : false,

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -21,7 +21,7 @@ jobs:
     - id: matrix
       run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\"}", $1, $2)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
     - name: Check matrix value
-      run: echo ${{ steps.matrix.outputs.value
+      run: echo ${{ steps.matrix.outputs.value }}
 
   build:
     needs: [ setup ]

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -67,7 +67,9 @@ jobs:
         steps.extension_info.outputs.EXT_PACKAGE_ID == '' || 
         steps.extension_info.outputs.EXT_VERSION == ''
       shell: bash
-      run: echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"
+      run: | 
+        echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"
+        exit 1
     
     - name: Debug Extension Info
       shell: bash
@@ -79,7 +81,6 @@ jobs:
         echo "GitHub Repository        : ${{ steps.extension_info.outputs.EXT_REPO }}"
         echo "Package ID               : ${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}"
         echo "Version                  : ${{ steps.extension_info.outputs.EXT_VERSION }}"
-        exit 1
   
     - name: Check if new
       id: check-if-new

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -50,7 +50,13 @@ jobs:
     - name: Extract Extension Info
       id: extension_info
       run: |
-        echo "EXT_TYPE=$(jq --raw-output '."type"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        type=$(jq --raw-output '."type"' ./${{ matrix.value.path }}/ExtensionManifest.json)"
+        if [ $type -eq 0 ]; then
+          type="Plugin"
+        elif [ $type -eq 1 ];then
+          type="IconPack"
+        fi
+        echo "EXT_TYPE=$type" >> $GITHUB_OUTPUT
         echo "EXT_NAME=$(jq --raw-output '."name"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
         echo "EXT_AUTHOR=$(jq --raw-output '."author"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
         echo "EXT_REPO=$(jq --raw-output '."repository"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        value: ${{fromJson(needs.setup.outputs.matrix)}}
+        value: ${{ fromJson(needs.setup.outputs.matrix) }}
         
     steps:
     - name: install dependecies

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -95,12 +95,12 @@ jobs:
     - name: Create new Extension
       if: fromJSON(steps.check-if-new.outputs.is_new) == 1
       env:
-        MACRO_DECK_API_TOKEN: ${{ secrets.MACRO_DECK_API_TOKEN }}
+        MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         curl -X 'POST' \
         'https://extensionstore.api.macro-deck.app/Extensions' \
         -H 'accept: */*' \
-        -H 'Authorization: Bearer $MACRO_DECK_API_TOKEN' \
+        -H 'Authorization: $MACRO_DECK_API_AUTH' \
         -H 'Content-Type: application/json' \
         -d '{
           "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         json=$(cat "${{ matrix.value.path }}/ExtensionManifest.json")
         echo "$json"
-        delim=$RANDOM
+        delim="EOF-${RANDOM}"
         echo "manifest<<${delim}" >> $GITHUB_ENV
         echo "$json" >> $GITHUB_ENV
         echo "${delim}" >> $GITHUB_ENV

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -146,7 +146,7 @@ jobs:
 
     - name: Notify Macro Bot
       id: notify-macro-bot
-      if: fromJSON(steps.upload-build-files.outputs.response).success == true
+      if: success() && fromJSON(steps.upload-build-files.outputs.response).success == true
       env:
         BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
         currVer: ${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -48,7 +48,7 @@ jobs:
         ext-ref: ${{ matrix.value.ref }}
         
     - name: Extract Extension Info
-      run: cat "${{ matrix.value.path }}/ExtensionManifest.json" | echo "manifest=$(cat -)" >> $GITHUB_ENV
+      run: cat "${{ matrix.value.path }}/ExtensionManifest.json" | tr '\n' ' ' | echo "manifest=$(cat -)" >> $GITHUB_ENV
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -151,6 +151,7 @@ jobs:
         BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
         currVer: ${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}
         newVer: ${{ fromJSON(steps.upload-build-files.outputs.response).newVersion }}
+        extType: ${{ fromJSON(steps.upload-build-files.outputs.response).extensionManifest.type }}
       run: |
         payload='{
           "toEveryone" : false,
@@ -160,11 +161,11 @@ jobs:
               "g":1,
               "b":1
             },
-            "title": "${{ fromJSON(env.manifest).name }}",
+            "title": "${{ format('[{0}] {1}', env.extType, fromJSON(env.manifest).name) }}",
             "fields" : [
               {
                 "name": "Version",
-                "value": "${{ env.currVer && format('%s -> ', env.currVer) || ''}}${{ env.newVer }}",
+                "value": "${{ env.currVer && format('{0} -> ', env.currVer) || ''}}${{ env.newVer }}",
                 "inline": false
               },
               {
@@ -176,7 +177,7 @@ jobs:
                 "name" : "${{ env.release && 'Release' || 'Commit' }}",
                 "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
                 "inline" : false
-              }${{ env.release && format(',{ "name": "Changelog", "value": "%s", "inline": false }', fromJSON(env.release).body) }}
+              }${{ env.release && format(',{ ''name''': ''Changelog''', ''value''': ''{0}'', ''inline''': false }', fromJSON(env.release).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -140,7 +140,7 @@ jobs:
       if: |
         (fromJSON(steps.upload-build-files.outputs.http_code) < 200 || 
         fromJSON(steps.upload-build-files.outputs.http_code) >= 300) &&
-        fromJSON(steps.upload-build-files.outputs.https_code) != 409
+        fromJSON(steps.upload-build-files.outputs.http_code) != 409
       run: |
         echo "::error ::Failed to upload files to build server. HTTP Code: ${{ steps.upload-build-files.outputs.http_code }} Response: ${{ steps.upload-build-files.outputs.response }}"
         exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -14,6 +14,8 @@ jobs:
       matrix: ${{ steps.matrix.outputs.value }}
     
     steps:
+    - name: install dependecies
+      run: apt-get install -y dos2unix
     - name: Checkout
       uses: actions/checkout@v3.3.0
     - name: Init Submodules

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Init Submodules
       run: git submodule update --init --recursive
     - id: matrix
-      run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\"}", $1, $2)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
+      run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1 $displaypath' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\",\"path\":\"%s\"}", $1, $2, $3)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
     - name: Check matrix value
       run: echo "${{ steps.matrix.outputs.value }}"
 
@@ -40,11 +40,20 @@ jobs:
         upsert-release: false
         ext-repo: ${{ matrix.value.repository }}
         ext-ref: ${{ matrix.value.ref }}
+        
+    - name: Extract Extension Info
+      id: extension_info
+      run: |
+        echo "EXT_VERSION=$(jq --raw-output '."version"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_TYPE=$(jq --raw-output '."type"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_PACKAGE_ID=$(jq --raw-output '."packageId"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
+        echo "EXT_TARGET_API_VERSION=$(jq '."target-plugin-api-version"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
   
     - name: Check if new
       id: check-if-new
+      if: steps.extension_info.outputs.EXT_TYPE == 'Plugin'
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions/RecklessBoon.MacroDeck.Discord')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions/${{ matrix.value.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 200 ]; then
           is_new=1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -33,11 +33,11 @@ jobs:
           fi
           case \$displaypath in 
             \$paths)
-              echo \$(git remote get-url origin | sed 's/https:\/\/github\.com\///' | sed 's/\.git//') \$sha1 \$displaypath | \\
-                awk 'NR > 1 {printf(\",\")} {printf(\"{\\\"repository\\\":\\\"%s\\\",\\\"ref\\\":\\\"%s\\\",\\\"path\\\":\\\"%s\\\"}\", \$1, \$2, \$3)}'
+              echo \$(git remote get-url origin | sed 's/https:\/\/github\.com\///' | sed 's/\.git//') \$sha1 \$displaypath
               ;;
-          esac
-        " | cat <(echo -n 'value=[') - <(echo -n ']') >> $GITHUB_OUTPUT
+          esac" | \
+          awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\",\"path\":\"%s\"}", $1, $2, $3)}' | \
+          cat <(echo -n 'value=[') - <(echo -n ']')  >> $GITHUB_OUTPUT
       
     - name: Check matrix value
       run: echo "${{ steps.matrix.outputs.value }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -80,7 +80,7 @@ jobs:
       
     - name: Build Extension
       id: build_extension
-      uses: RecklessBoon/Macro-Deck-Extension-Build-Action@main
+      uses: RecklessBoon/Macro-Deck-Extension-Build-Action@4f32742817c2537e4472ab35fd9a93e54f600822
       with:
         upsert-release: false
         ext-repo: ${{ matrix.value.repository }}

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -71,4 +71,4 @@ jobs:
     
     - name: Show artifact output
       shell: bash
-      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result)[matrix.value.respository] }}"
+      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result)[matrix.value.respository].artifact-name }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Check if new
       id: check-if-new
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions/${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || 'Icon/' }}${{ matrix.value.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ matrix.value.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 200 ]; then
           is_new=1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -26,15 +26,27 @@ jobs:
   build:
     needs: [ setup ]
     runs-on: ubuntu-latest
+    outputs:
+      artifact-names: ${{ steps.build_extension.outputs.artifact-name }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         value: ${{fromJson(needs.setup.outputs.matrix)}}
         
     steps:
     - name: Build Extension
+      id: build_extension
       uses: RecklessBoon/Macro-Deck-Extension-Build-Action@main
       with:
         upsert-release: false
         ext-repo: ${{ matrix.value.repository }}
         ext-ref: ${{ matrix.value.ref }}
+
+  post-process:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Show artifact output
+      shell: bash
+      run: echo "${{ needs.build.outputs.artifact-names }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -97,7 +97,7 @@ jobs:
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed' || true
-        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json") | tr -d '\n'
+        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json" | tr -d '\n')
         echo -e "Response:\n$response"
         echo "response=$response" >> $GITHUB_OUTPUT
         

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -71,7 +71,7 @@ jobs:
         tag=$(git tag --contains "${{ matrix.value.ref }}" | head -n 1)
         if [ -n "$tag" ]; then
           echo "Tag $tag found for commit $ref. Now looking for release..."
-          release_body=$(gh release view $tag --json body || true)
+          release_body=$(gh release view $tag --json body,name || true)
         fi
         echo "release=$release" >> $GITHUB_ENV
       
@@ -163,8 +163,8 @@ jobs:
                 "inline": false
               },
               {
-                "name" : "SHA",
-                "value" : "${{ matrix.value.ref }}" , 
+                "name" : "${{ env.release && 'Release' || 'Commit' }}",
+                "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
                 "inline" : false
               }${{ env.release && format(',{ "name": "Changelog", "value": "%s", "inline": false }', fromJSON(env.release).body) }}
             ]

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -100,7 +100,7 @@ jobs:
         curl -X 'POST' \
         'https://extensionstore.api.macro-deck.app/Extensions' \
         -H 'accept: application/json' \
-        -H 'Authorization: Bearer $MACRO_DECK_API_TOKEN' \
+        -H 'Authentication: Bearer $MACRO_DECK_API_TOKEN' \
         -H 'Content-Type: application/json' \
         -d '{
           "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -146,7 +146,10 @@ jobs:
 
     - name: Notify Macro Bot
       id: notify-macro-bot
-      if: success() && fromJSON(steps.upload-build-files.outputs.response).success == true
+      if: |
+        success() &&
+        steps.upload-build-files.outputs.response && 
+        fromJSON(steps.upload-build-files.outputs.response).success == true
       env:
         BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
         currVer: ${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        pr_paths=$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path' 2> /dev/null)
+        pr_paths=$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path' 2> /dev/null || true)
         git submodule --quiet foreach "
           paths=\"$pr_paths\"
           if [ -z \$paths ]; then

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -137,8 +137,9 @@ jobs:
         
     - name: Check upload response
       if: |
-        steps.upload-build-files.outputs.http_code < 200 || 
-        steps.upload-build-files.outputs.http_code >= 300
+        (steps.upload-build-files.outputs.http_code < 200 || 
+        steps.upload-build-files.outputs.http_code >= 300) &&
+        steps.upload-build-files.outputs.https_code != 409
       run: |
         echo "::error ::Failed to upload files to build server. HTTP Code: ${{ steps.upload-build-files.outputs.http_code }} Response: ${{ steps.upload-build-files.outputs.response }}"
         exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Check if new
       id: check-if-new
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' '${{ vars.EXTENSION_STORE_API_URL }}/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' '${{ vars.EXTENSION_STORE_API_URL }}/extensions/${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 404 ]; then
           is_new=1
@@ -104,7 +104,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         response=$(curl --fail-with-body -X POST \
-          '${{ vars.EXTENSION_STORE_API_URL }}/ExtensionsFiles/Upload' \
+          '${{ vars.EXTENSION_STORE_API_URL }}/extensiosn/files/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        pr_paths=$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path' || true)
+        pr_paths=$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path' 2> /dev/null)
         git submodule --quiet foreach "
           paths=\"$pr_paths\"
           if [ -z \$paths ]; then

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -164,7 +164,7 @@ jobs:
             "fields" : [
               {
                 "name": "Version",
-                "value": "${{ (env.currVer && format('%s -> ', env.currVer)) env.newVer }}",
+                "value": "${{ env.currVer && format('%s -> ', env.currVer) || ''}}${{ env.newVer }}",
                 "inline": false
               },
               {

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [ setup ]
     runs-on: ubuntu-latest
     outputs:
-      artifact-names: ${{ steps.build_extension.outputs.artifact-name }}
+      artifact-names: ${{ env.artifact-names }}
     strategy:
       fail-fast: true
       matrix:
@@ -42,6 +42,9 @@ jobs:
         upsert-release: false
         ext-repo: ${{ matrix.value.repository }}
         ext-ref: ${{ matrix.value.ref }}
+        
+    - name: Combine artifact name
+      run: echo "artifact-names=${{ env.artifact-names }},${{ steps.build_extension.outputs.artifact-name }}" >> $GITHUB_ENV
 
   post-process:
     needs: [ build ]

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -181,7 +181,7 @@ jobs:
                 "name" : "${{ env.release && 'Release' || 'Commit' }}",
                 "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
                 "inline" : false
-              }${{ env.release && format(',{{ "name": "Changelog", "value": "{0}", "inline": false }}', fromJSON(env.release).body) }}
+              }${{ env.release && fromJSON(env.release).body) && format(',{{ "name": "Changelog", "value": "{0}", "inline": false }}', fromJSON(env.release).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
     - name: install dependecies
-      run: apt-get install -y dos2unix
+      run: sudo apt-get install -y dos2unix
     - name: Checkout
       uses: actions/checkout@v3.3.0
     - name: Init Submodules

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -149,37 +149,37 @@ jobs:
       if: fromJSON(steps.upload-build-files.outputs.response).success == true
       env:
         BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
-        CURR_VER: ${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}
-        NEW_VER: ${{ fromJSON(steps.upload-build-files.outputs.response).newVersion }}
+        currVer: ${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}
+        newVer: ${{ fromJSON(steps.upload-build-files.outputs.response).newVersion }}
       run: |
-        payload="{
-          'toEveryone' : false,
-          'embed' : {
-            'color' : {
-              'r':0,
-              'g':1,
-              'b':1
+        payload='{
+          "toEveryone" : false,
+          "embed" : {
+            "color" : {
+              "r":0,
+              "g":1,
+              "b":1
             },
-            'title': '${{ fromJSON(env.manifest).name }}'',
-            'fields' : [
+            "title": "${{ fromJSON(env.manifest).name }}",
+            "fields" : [
               {
-                'name': 'Version',
-                'value': '$CURR_VER ${{ env.CURR_VER != env.NEW_VER && format(' -> %s', env.NEW_VER) }}',
-                'inline': false
+                "name": "Version",
+                "value": "${{ (env.currVer && format('%s -> ', env.currVer)) env.newVer }}",
+                "inline": false
               },
               {
-                'name': 'Repository URL',
-                'value': 'https://github.com/${{ matrix.value.repository }}',
-                'inline': false
+                "name": "Repository URL",
+                "value": "https://github.com/${{ matrix.value.repository }}",
+                "inline": false
               },
               {
-                'name' : '${{ env.release && 'Release' || 'Commit' }}',
-                'value' : '${{ env.release && fromJSON(env.release).name || matrix.value.ref }}' , 
-                'inline' : false
+                "name" : "${{ env.release && 'Release' || 'Commit' }}",
+                "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
+                "inline" : false
               }${{ env.release && format(',{ "name": "Changelog", "value": "%s", "inline": false }', fromJSON(env.release).body) }}
             ]
           }
-        }"
+        }'
         curl --fail-with-body -o "./${{ fromJSON(env.manifest).packageId }}-bot-notify-response.json" -X POST \
           '${{ vars.BOT_API_URL }}/webhook/${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && 'newextension' || 'updateextension' }}' \
           -H 'accept: */*' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -125,7 +125,7 @@ jobs:
               "g":1,
               "b":1
             },
-            "description" : "${{ github.event_name == 'pull_request' && github.event.pull_request.title || 'Plugin(s) Deployed to Extension Store' }}",
+            "title": "${{ github.event_name == 'pull_request' && github.event.pull_request.title || 'Plugin Deployed to Extension Store' }}"
             "fields" : [
               {
                 "name": "Path",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -5,10 +5,12 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    types: [ closed ]
   workflow_dispatch:
 
 jobs:
   setup:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.value }}
@@ -24,6 +26,7 @@ jobs:
       run: echo "${{ steps.matrix.outputs.value }}"
 
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     needs: [ setup ]
     runs-on: ubuntu-latest
     environment: development
@@ -107,3 +110,43 @@ jobs:
         fromJSON(steps.upload-build-files.outputs.response).errorCode != 4
       run: |
         echo "::error ::Failed to upload files to build server. Response: ${{ steps.upload-build-files.outputs.response }}" && exit 1
+
+    - name: Notify Macro Bot
+      if: fromJSON(steps.upload-build-files.outputs.response).success == true
+      env:
+        BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
+      run: |
+        curl --fail-with-body -o "./${{ fromJSON(env.manifest).packageId }}-bot-notify-response.json" -X POST \
+          '${{ vars.BOT_API_URL }}/webhook/${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && 'newextension' || 'updateextension' }}' \
+          -H 'accept: */*'
+          -H "Authorization: $BOT_API_AUTH" \
+          -H 'Content-Type: application/json' \
+          -d '{
+            "toEveryone" : false,
+            "embed" : {
+              "color" : {
+                "r":0,
+                "g":1,
+                "b":1
+              },
+              "description" : "${{ github.event_name == 'pull_request' && github.event.pull_request.title || 'Plugin(s) Deployed to Extension Store' }}",
+              "fields" : [
+                {
+                  "name": "Path",
+                  "value": "${{ matrix.value.path }}",
+                  "inline": false
+                },
+                {
+                  "name": "Repository URL",
+                  "value": "${{ matrix.value.repository }}",
+                  "inline": false
+                },
+                {
+                  "name" : "SHA",
+                  "value" : "${{ matrix.value.ref }}" , 
+                  "inline" : false
+                }${{ github.event_name == 'pull_request' && format(', {"name": "PR Body", "value": "{0}", "inline": false }', github.event.pull_request.body) || '' }}
+              ]
+            }
+          }'
+            

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -43,14 +43,34 @@ jobs:
         ext-repo: ${{ matrix.value.repository }}
         ext-ref: ${{ matrix.value.ref }}
         
-    - name: Combine artifact name
-      run: echo "artifact-names=${{ env.artifact-names }},${{ steps.build_extension.outputs.artifact-name }}" >> $GITHUB_ENV
-
+    - name: Matrix outputs - write
+      uses: cloudposse/github-action-matrix-outputs-write@452cd7eaf9068d160987d0ca0a06895fecb40bd8
+      with:
+        # Matrix step name
+        matrix-step-name: build
+        # Matrix key
+        matrix-key: ${{ matrix.value.repository }}
+        # YAML structured map of outputs
+        outputs: |-
+          artifact-name: ${{ steps.build_extension.outputs.artifact-name }}
+    
   post-process:
-    needs: [ build ]
+    needs: [ setup, build ]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        value: ${{fromJson(needs.setup.outputs.matrix)}}
     
     steps:
+    - name: Matrix outputs - read
+      id: artifact-names
+      # You may pin to the exact commit or the version.
+      uses: cloudposse/github-action-matrix-outputs-read@ea1c28d66c34b8400391ed74d510f66abc392d5e
+      with:
+        # Matrix step name
+        matrix-step-name: build
+    
     - name: Show artifact output
       shell: bash
-      run: echo "${{ needs.build.outputs.artifact-names }}"
+      run: echo "Artifact name = ${{ steps.artifact-names.outputs.result[matrix..value.repository] }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -73,4 +73,4 @@ jobs:
     
     - name: Show artifact output
       shell: bash
-      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result)[matrix..value.repository] }}"
+      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result)[matrix.value.repository] }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Check if new
       id: check-if-new
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ matrix.value.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 200 ]; then
           is_new=1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -71,7 +71,7 @@ jobs:
         tag=$(git tag --contains "${{ matrix.value.ref }}" | head -n 1)
         if [ -n "$tag" ]; then
           echo "Tag $tag found for commit $ref. Now looking for release..."
-          release=$(gh release view $tag --json body,name || true)
+          release=$(gh release view $tag --json body,name | sed "s/'/''/" || true)
         fi
         if [ -n "$release" ]; then
           echo "Release found! $release"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -139,7 +139,7 @@ jobs:
                 "name" : "SHA",
                 "value" : "${{ matrix.value.ref }}" , 
                 "inline" : false
-              }${{ github.event_name == 'pull_request' && format(', {"name": "PR Body", "value": "{0}", "inline": false }', github.event.pull_request.body) || '' }}
+              }${{ github.event_name == 'pull_request' && format(', {{"name": "PR Body", "value": "{0}", "inline": false }}', github.event.pull_request.body) || '' }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -56,7 +56,18 @@ jobs:
         echo "EXT_PACKAGE_ID=$(jq --raw-output '."packageId"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
         echo "EXT_VERSION=$(jq --raw-output '."version"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
         echo "EXT_D_SUPPORT_USER_ID=$(jq '."dSupportUserId"' ./${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_OUTPUT
-  
+    
+    - name: Debug Extension Info
+      shell: bash
+      run: |
+        echo "[Extension Info Values]"
+        echo "Type                     : ${{ steps.extension_info.outputs.EXT_TYPE }}"
+        echo "Name                     : ${{ steps.extension_info.outputs.EXT_NAME }}"
+        echo "Author                   : ${{ steps.extension_info.outputs.EXT_AUTHOR }}"
+        echo "GitHub Repository        : ${{ steps.extension_info.outputs.EXT_REPO }}"
+        echo "Package ID               : ${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}"
+        echo "Version                  : ${{ steps.extension_info.outputs.EXT_VERSION }}"
+
     - name: Validate Extension Info
       if: |
         steps.extension_info.outputs.EXT_TYPE == '' || 
@@ -69,48 +80,16 @@ jobs:
       run: | 
         echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"
         exit 1
-    
-    - name: Debug Extension Info
-      shell: bash
-      run: |
-        echo "[Extension Info Values]"
-        echo "Type                     : ${{ steps.extension_info.outputs.EXT_TYPE }}"
-        echo "Name                     : ${{ steps.extension_info.outputs.EXT_NAME }}"
-        echo "Author                   : ${{ steps.extension_info.outputs.EXT_AUTHOR }}"
-        echo "GitHub Repository        : ${{ steps.extension_info.outputs.EXT_REPO }}"
-        echo "Package ID               : ${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}"
-        echo "Version                  : ${{ steps.extension_info.outputs.EXT_VERSION }}"
   
     - name: Check if new
       id: check-if-new
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' '${{ env.EXTENSION_STORE_API_URL }}/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 404 ]; then
           is_new=1
         fi
         echo "is_new=$is_new" >> $GITHUB_OUTPUT
-        
-    - name: Create new Extension
-      if: fromJSON(steps.check-if-new.outputs.is_new) == 1
-      env:
-        MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
-      run: |
-        curl -X 'POST' \
-        --fail \
-        'https://extensionstore.api.macro-deck.app/Extensions' \
-        -H 'accept: */*' \
-        -H "Authorization: $MACRO_DECK_API_AUTH" \
-        -H 'Content-Type: application/json' \
-        -d '{
-          "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",
-          "extensionType": ${{ steps.extension_info.outputs.EXT_TYPE != 'Plugin' && 1 || 0 }},
-          "name": "${{ steps.extension_info.outputs.EXT_NAME }}",
-          "author": "${{ steps.extension_info.outputs.EXT_AUTHOR }}",
-          "gitHubRepository": "${{ steps.extension_info.outputs.EXT_REPO }}",
-          "dSupportUserId": "${{ steps.extension_info.outputs.EXT_SUPPORT_DISCORD_USER_ID }}",
-          "downloads": 0
-        }'
         
     - name: Download a Build Artifact
       uses: actions/download-artifact@v3.0.2
@@ -123,24 +102,19 @@ jobs:
       env:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
-        http_code=$(curl -X POST \
-          --silent --output './upload-build-files.${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}.log' --write-out '%{http_code}' \
-          'https://extensionstore.api.macro-deck.app/ExtensionsFiles/Upload' \
+        response=$(curl -X POST \
+          '${{ env.EXTENSION_STORE_API_URL }}/ExtensionsFiles/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed')
-        response="$(cat './upload-build-files.${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}.log')"
-        echo "Upload response code: $http_code"
-        echo -e "Response:\n$(cat './upload-build-files.${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}.log')"
-        echo "http_code=$http_code" >> $GITHUB_OUTPUT
+        echo -e "Response:\n$response"
         echo "response=$response" >> $GITHUB_OUTPUT
         
     - name: Check upload response
       if: |
-        (fromJSON(steps.upload-build-files.outputs.http_code) < 200 || 
-        fromJSON(steps.upload-build-files.outputs.http_code) >= 300) &&
-        fromJSON(steps.upload-build-files.outputs.http_code) != 409
+        fromJSON(steps.upload-build-files.outputs.response).success == 'false' &&
+        fromJSON(steps.upload-build-files.outputs.response).errorCode != 4
       run: |
-        echo "::error ::Failed to upload files to build server. HTTP Code: ${{ steps.upload-build-files.outputs.http_code }} Response: ${{ steps.upload-build-files.outputs.response }}"
+        echo "::error ::Failed to upload files to build server. Response: ${{ steps.upload-build-files.outputs.response }}"
         exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -124,7 +124,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         http_code=$(curl \
-          --fail --silent --output /dev/null --write-out %{http_code} \          
+          --silent --output /dev/null --write-out %{http_code} \          
           -X 'POST' \
           'https://extensionstore.api.macro-deck.app/ExtensionsFiles/Upload' \
           -H 'accept: */*' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -51,9 +51,8 @@ jobs:
       run: |
         delim="EOF-${RANDOM}"
         echo "manifest<<${delim}" >> $GITHUB_ENV
-        cat "${{ matrix.value.path }}/ExtensionManifest.json" >> $GITHUB_ENV
-        echo "" >> $GITHUB_ENV
-        echo "${delim}" >> $GITHUB_ENV
+        cat "${{ matrix.value.path }}/ExtensionManifest.json" | awk '{$1=$1};NF' >> $GITHUB_ENV
+        echo -e "\n${delim}" >> $GITHUB_ENV
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Extract Extension Info
       id: extension_info
       run: |
-        type=$(jq --raw-output '."type"' ./${{ matrix.value.path }}/ExtensionManifest.json)"
+        type=$(jq --raw-output '."type"' ./${{ matrix.value.path }}/ExtensionManifest.json)
         if [ $type -eq 0 ]; then
           type="Plugin"
         elif [ $type -eq 1 ];then

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -123,9 +123,8 @@ jobs:
       env:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
-        http_code=$(curl \
-          --silent --output /dev/null --write-out '%{http_code}' \          
-          -X 'POST' \
+        http_code=$(curl -X POST \
+          --silent --output /dev/null --write-out '%{http_code}' \
           'https://extensionstore.api.macro-deck.app/ExtensionsFiles/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -14,8 +14,6 @@ jobs:
       matrix: ${{ steps.matrix.outputs.value }}
     
     steps:
-    - name: install dependecies
-      run: sudo apt-get install -y dos2unix
     - name: Checkout
       uses: actions/checkout@v3.3.0
     - name: Init Submodules
@@ -35,6 +33,9 @@ jobs:
         value: ${{fromJson(needs.setup.outputs.matrix)}}
         
     steps:
+    - name: install dependecies
+      run: sudo apt-get install -y dos2unix
+
     - name: Checkout
       uses: actions/checkout@v3.3.0
       

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -100,7 +100,7 @@ jobs:
         curl -X 'POST' \
         'https://extensionstore.api.macro-deck.app/Extensions' \
         -H 'accept: */*' \
-        -H 'Authorization: $MACRO_DECK_API_AUTH' \
+        -H "Authorization: $MACRO_DECK_API_AUTH" \
         -H 'Content-Type: application/json' \
         -d '{
           "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -1,4 +1,4 @@
-name: Build Extensions
+name: Compile Extensions
 
 on:
   push:
@@ -16,8 +16,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3.3.0
+    - name: Init Submodules
+      run: git submodule update --init --recursive
     - id: matrix
       run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\"}", $1, $2)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
+    - name: Check matrix value
+      run: echo ${{ steps.matrix.outputs.value
 
   build:
     needs: [ setup ]

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -162,7 +162,7 @@ jobs:
             "fields" : [
               {
                 "name": "Version",
-                "value": "${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }} -> ${{ fromJSON(steps.upload-build-files.outputs.response).newVersion}}",
+                "value": "${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }}${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion != fromJSON(steps.upload-build-files.outputs.response).newVersion}} && format(' -> %s', fromJSON(steps.upload-build-files.outputs.response).newVersion) || '' }}",
                 "inline": false
               },
               {

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -48,41 +48,31 @@ jobs:
         ext-ref: ${{ matrix.value.ref }}
         
     - name: Extract Extension Info
-      id: extension_info
-      run: |
-        type=$(cat ./${{ matrix.value.path }} | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).type')
-        if [ $type -eq 0 ]; then
-          type="Plugin"
-        elif [ $type -eq 1 ];then
-          type="IconPack"
-        fi
-        echo "EXT_TYPE=$type" >> $GITHUB_OUTPUT
-        echo "EXT_NAME=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).name')" >> $GITHUB_OUTPUT
-        echo "EXT_AUTHOR=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).author')" >> $GITHUB_OUTPUT
-        echo "EXT_REPO=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).repository')" >> $GITHUB_OUTPUT
-        echo "EXT_PACKAGE_ID=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).packageId')" >> $GITHUB_OUTPUT
-        echo "EXT_VERSION=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).version')" >> $GITHUB_OUTPUT
-        echo "EXT_D_SUPPORT_USER_ID=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).dSupportUserId')" >> $GITHUB_OUTPUT
+      uses: rgarcia-phi/json-to-variables@9835d537368468c4e4de5254dc3efeadda183793
+      with:
+        filename: ${{ matrix.value.path }}/ExtensionManifest.json
+        prefix: ext
+        masked: false
     
     - name: Debug Extension Info
       shell: bash
       run: |
         echo "[Extension Info Values]"
-        echo "Type                     : ${{ steps.extension_info.outputs.EXT_TYPE }}"
-        echo "Name                     : ${{ steps.extension_info.outputs.EXT_NAME }}"
-        echo "Author                   : ${{ steps.extension_info.outputs.EXT_AUTHOR }}"
-        echo "GitHub Repository        : ${{ steps.extension_info.outputs.EXT_REPO }}"
-        echo "Package ID               : ${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}"
-        echo "Version                  : ${{ steps.extension_info.outputs.EXT_VERSION }}"
+        echo "Type                     : ${{ env.ext_type }}"
+        echo "Name                     : ${{ env.ext_name }}"
+        echo "Author                   : ${{ env.ext_author }}"
+        echo "GitHub Repository        : ${{ env.ext_repository }}"
+        echo "Package ID               : ${{ env.ext_packageId }}"
+        echo "Version                  : ${{ env.ext_version }}"
 
     - name: Validate Extension Info
       if: |
-        steps.extension_info.outputs.EXT_TYPE == '' || 
-        steps.extension_info.outputs.EXT_NAME == '' || 
-        steps.extension_info.outputs.EXT_AUTHOR == '' || 
-        steps.extension_info.outputs.EXT_REPO == '' || 
-        steps.extension_info.outputs.EXT_PACKAGE_ID == '' || 
-        steps.extension_info.outputs.EXT_VERSION == ''
+        env.ext_type == '' || 
+        env.ext_name == '' || 
+        env.ext_author == '' || 
+        env.ext_repository == '' || 
+        env.ext_packageId == '' || 
+        env.ext_version == ''
       shell: bash
       run: | 
         echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -117,40 +117,45 @@ jobs:
       env:
         BOT_API_AUTH: "Bearer ${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && secrets.BOT_NEW_API_TOKEN || secrets.BOT_UPDATE_API_TOKEN }}"
       run: |
+        payload='{
+          "toEveryone" : false,
+          "embed" : {
+            "color" : {
+              "r":0,
+              "g":1,
+              "b":1
+            },
+            "description" : "${{ github.event_name == 'pull_request' && github.event.pull_request.title || 'Plugin(s) Deployed to Extension Store' }}",
+            "fields" : [
+              {
+                "name": "Path",
+                "value": "${{ matrix.value.path }}",
+                "inline": false
+              },
+              {
+                "name": "Repository URL",
+                "value": "${{ matrix.value.repository }}",
+                "inline": false
+              },
+              {
+                "name" : "SHA",
+                "value" : "${{ matrix.value.ref }}" , 
+                "inline" : false
+              }${{ github.event_name == 'pull_request' && format(', {"name": "PR Body", "value": "{0}", "inline": false }', github.event.pull_request.body) || '' }}
+            ]
+          }
+        }'
         curl --fail-with-body -o "./${{ fromJSON(env.manifest).packageId }}-bot-notify-response.json" -X POST \
           '${{ vars.BOT_API_URL }}/webhook/${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && 'newextension' || 'updateextension' }}' \
           -H 'accept: */*'
           -H "Authorization: $BOT_API_AUTH" \
           -H 'Content-Type: application/json' \
-          -d '{
-            "toEveryone" : false,
-            "embed" : {
-              "color" : {
-                "r":0,
-                "g":1,
-                "b":1
-              },
-              "description" : "${{ github.event_name == 'pull_request' && github.event.pull_request.title || 'Plugin(s) Deployed to Extension Store' }}",
-              "fields" : [
-                {
-                  "name": "Path",
-                  "value": "${{ matrix.value.path }}",
-                  "inline": false
-                },
-                {
-                  "name": "Repository URL",
-                  "value": "${{ matrix.value.repository }}",
-                  "inline": false
-                },
-                {
-                  "name" : "SHA",
-                  "value" : "${{ matrix.value.ref }}" , 
-                  "inline" : false
-                }${{ github.event_name == 'pull_request' && format(', {"name": "PR Body", "value": "{0}", "inline": false }', github.event.pull_request.body) || '' }}
-              ]
-            }
-          }' || true
+          -d "$payload" || true
+        failed=$?
         response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json")
         echo -e "Response:\n$response"
+        if [ $failed -ne 0 ]; then 
+          exit 1; 
+        fi
         echo "response=$response" >> $GITHUB_OUTPUT
             

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     needs: [ setup ]
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -177,7 +177,7 @@ jobs:
                 "name" : "${{ env.release && 'Release' || 'Commit' }}",
                 "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
                 "inline" : false
-              }${{ env.release && format(',{ ''name'': ''Changelog'', ''value'': ''{0}'', ''inline'': false }', fromJSON(env.release).body) }}
+              }${{ env.release && format(',{{ ''name'': ''Changelog'', ''value'': ''{0}'', ''inline'': false }}', fromJSON(env.release).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -128,10 +128,11 @@ jobs:
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed')
+        echo "$response"
         echo "response=$response" >> $GITHUB_OUTPUT
         
     - name: Check upload response
-      if: fromJSON(steps.upload-build-files.outputs.response).type != ''
+      if: steps.upload-build-files.outputs.response != '' && fromJSON(steps.upload-build-files.outputs.response).type != ''
       run: |
         echo "::error ::Failed to upload files to build server. Resonse: ${{ steps.upload-build-files.outputs.response }}"
         exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Check if new
       id: check-if-new
       run:  |
-        http_code=$(curl -X 'GET' --fail --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 404 ]; then
           is_new=1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -111,10 +111,11 @@ jobs:
         fromJSON(env.manifest).author == '' || 
         fromJSON(env.manifest).repository == '' || 
         fromJSON(env.manifest).packageId == '' || 
-        fromJSON(env.manifest).version == ''
+        fromJSON(env.manifest).version == '' ||
+        fromJSON(env.manifest).target-plugin-api-version == ''
       shell: bash
       run: | 
-        echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]" && exit 1
+        echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [name, version, type, author, packageId, repository, target-plugin-api-version]" && exit 1
         
     - name: Download a Build Artifact
       uses: actions/download-artifact@v3.0.2

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -177,7 +177,7 @@ jobs:
                 "name" : "${{ env.release && 'Release' || 'Commit' }}",
                 "value" : "${{ env.release && fromJSON(env.release).name || matrix.value.ref }}" , 
                 "inline" : false
-              }${{ env.release && format(',{{ "name: "Changelog", "value": "{0}", "inline": false }}', fromJSON(env.release).body) }}
+              }${{ env.release && format(',{{ "name": "Changelog", "value": "{0}", "inline": false }}', fromJSON(env.release).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -51,9 +51,10 @@ jobs:
       run: |
         json=$(cat "${{ matrix.value.path }}/ExtensionManifest.json")
         echo "$json"
-        echo "manifest<<EOF" >> $GITHUB_ENV
+        delim=$RANDOM
+        echo "manifest<<${delim}" >> $GITHUB_ENV
         echo "$json" >> $GITHUB_ENV
-        echo "EOF" >> $GITHUB_ENV
+        echo "${delim}" >> $GITHUB_ENV
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -100,7 +100,7 @@ jobs:
         curl -X 'POST' \
         'https://extensionstore.api.macro-deck.app/Extensions' \
         -H 'accept: */*' \
-        -H 'Authentication: Bearer $MACRO_DECK_API_TOKEN' \
+        -H 'Authorization: Bearer $MACRO_DECK_API_TOKEN' \
         -H 'Content-Type: application/json' \
         -d '{
           "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -40,6 +40,9 @@ jobs:
         upsert-release: false
         ext-repo: ${{ matrix.value.repository }}
         ext-ref: ${{ matrix.value.ref }}
+
+    - name: Init Submodules
+      run: git submodule update --init --recursive ${{ matrix.value.path }}
         
     - name: Extract Extension Info
       id: extension_info

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -26,8 +26,6 @@ jobs:
   build:
     needs: [ setup ]
     runs-on: ubuntu-latest
-    outputs:
-      artifact-names: ${{ env.artifact-names }}
     strategy:
       fail-fast: true
       matrix:
@@ -47,7 +45,7 @@ jobs:
       uses: cloudposse/github-action-matrix-outputs-write@452cd7eaf9068d160987d0ca0a06895fecb40bd8
       with:
         # Matrix step name
-        matrix-step-name: build
+        matrix-step-name: ${{ github.job }}
         # Matrix key
         matrix-key: ${{ matrix.value.repository }}
         # YAML structured map of outputs
@@ -73,4 +71,4 @@ jobs:
     
     - name: Show artifact output
       shell: bash
-      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result)[matrix.value.repository] }}"
+      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result) }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -147,7 +147,7 @@ jobs:
         }'
         curl --fail-with-body -o "./${{ fromJSON(env.manifest).packageId }}-bot-notify-response.json" -X POST \
           '${{ vars.BOT_API_URL }}/webhook/${{ fromJSON(steps.upload-build-files.outputs.response).newPlugin && 'newextension' || 'updateextension' }}' \
-          -H 'accept: */*'
+          -H 'accept: */*' \
           -H "Authorization: $BOT_API_AUTH" \
           -H 'Content-Type: application/json' \
           -d "$payload" || true

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -132,14 +132,15 @@ jobs:
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed')
         response="$(cat './upload-build-files.${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}.log')"
         echo "Upload response code: $http_code"
+        echo -e "Response:\n$(cat './upload-build-files.${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}.log')"
         echo "http_code=$http_code" >> $GITHUB_OUTPUT
         echo "response=$response" >> $GITHUB_OUTPUT
         
     - name: Check upload response
       if: |
-        (steps.upload-build-files.outputs.http_code < 200 || 
-        steps.upload-build-files.outputs.http_code >= 300) &&
-        steps.upload-build-files.outputs.https_code != 409
+        (fromJSON(steps.upload-build-files.outputs.http_code) < 200 || 
+        fromJSON(steps.upload-build-files.outputs.http_code) >= 300) &&
+        fromJSON(steps.upload-build-files.outputs.https_code) != 409
       run: |
         echo "::error ::Failed to upload files to build server. HTTP Code: ${{ steps.upload-build-files.outputs.http_code }} Response: ${{ steps.upload-build-files.outputs.response }}"
         exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -32,6 +32,12 @@ jobs:
         value: ${{fromJson(needs.setup.outputs.matrix)}}
         
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3.3.0
+      
+    - name: Init Submodule
+      run: git submodule update --init --recursive ${{ matrix.value.path }}
+      
     - name: Build Extension
       id: build_extension
       continue-on-error: true
@@ -40,9 +46,6 @@ jobs:
         upsert-release: false
         ext-repo: ${{ matrix.value.repository }}
         ext-ref: ${{ matrix.value.ref }}
-
-    - name: Init Submodules
-      run: git submodule update --init --recursive ${{ matrix.value.path }}
         
     - name: Extract Extension Info
       id: extension_info

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -49,11 +49,10 @@ jobs:
         
     - name: Extract Extension Info
       run: |
-        json=$(cat "${{ matrix.value.path }}/ExtensionManifest.json")
-        echo "$json"
         delim="EOF-${RANDOM}"
         echo "manifest<<${delim}" >> $GITHUB_ENV
-        echo "$json" >> $GITHUB_ENV
+        cat "${{ matrix.value.path }}/ExtensionManifest.json" >> $GITHUB_ENV
+        echo "" >> $GITHUB_ENV
         echo "${delim}" >> $GITHUB_ENV
     
     - name: Debug Extension Info

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -97,7 +97,7 @@ jobs:
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed' || true
-        response=$(cat ${{ fromJSON(env.manifest).packageId }})
+        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json")
         echo -e "Response:\n$response"
         echo "response=$response" >> $GITHUB_OUTPUT
         

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -158,7 +158,7 @@ jobs:
               "g":1,
               "b":1
             },
-            "title": "${{ matrix.value.path }}",
+            "title": "${{ fromJSON(env.manifest).name }}",
             "fields" : [
               {
                 "name": "Version",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -99,8 +99,8 @@ jobs:
       run: |
         curl -X 'POST' \
         'https://extensionstore.api.macro-deck.app/Extensions' \
-        -H 'accept: application/json' \
-        -H 'Authentication: Bearer $MACRO_DECK_API_TOKEN' \
+        -H 'accept: */*' \
+        -H 'Authorization: Bearer $MACRO_DECK_API_TOKEN' \
         -H 'Content-Type: application/json' \
         -d '{
           "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -96,7 +96,7 @@ jobs:
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
-          -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed' || true)
+          -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed' || true
         response=$(cat ${{ fromJSON(env.manifest).packageId }})
         echo -e "Response:\n$response"
         echo "response=$response" >> $GITHUB_OUTPUT

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -40,35 +40,18 @@ jobs:
         upsert-release: false
         ext-repo: ${{ matrix.value.repository }}
         ext-ref: ${{ matrix.value.ref }}
+  
+    - name: Check if new
+      id: check-if-new
+      run:  |
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' 'https://extensionstore.api.macro-deck.app/Extensions/RecklessBoon.MacroDeck.Discord')
+        is_new=0
+        if [ $(($http_code)) -eq 200 ]; then
+          is_new=1
+        fi
+        echo "is_new=$is_new" >> $GITHUB_OUTPUT
         
-    - name: Matrix outputs - write
-      uses: cloudposse/github-action-matrix-outputs-write@452cd7eaf9068d160987d0ca0a06895fecb40bd8
-      with:
-        # Matrix step name
-        matrix-step-name: ${{ github.job }}
-        # Matrix key
-        matrix-key: ${{ matrix.value.repository }}
-        # YAML structured map of outputs
-        outputs: |-
-          artifact-name: ${{ steps.build_extension.outputs.artifact-name }}
-    
-  post-process:
-    needs: [ setup, build ]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        value: ${{fromJson(needs.setup.outputs.matrix)}}
-    
-    steps:
-    - name: Matrix outputs - read
-      id: artifact-names
-      # You may pin to the exact commit or the version.
-      uses: cloudposse/github-action-matrix-outputs-read@ea1c28d66c34b8400391ed74d510f66abc392d5e
-      with:
-        # Matrix step name
-        matrix-step-name: build
-    
-    - name: Show artifact output
-      shell: bash
-      run: echo "Artifact name = ${{ fromJson(steps.artifact-names.outputs.result)[matrix.value.respository].artifact-name }}"
+    - name: Create new Extension
+      if: steps.check-if-new.outputs.is_new == '1'
+      run: echo "Need to create the extension"
+      

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -102,7 +102,7 @@ jobs:
         -H 'Content-Type: application/json' \
         -d '{
           "packageId": "${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}",
-          "extensionType": ${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && 0 || 1 }},
+          "extensionType": ${{ steps.extension_info.outputs.EXT_TYPE != 'Plugin' && 1 || 0 }},
           "name": "${{ steps.extension_info.outputs.EXT_NAME }}",
           "author": "${{ steps.extension_info.outputs.EXT_AUTHOR }}",
           "gitHubRepository": "${{ steps.extension_info.outputs.EXT_REPO }}",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -132,7 +132,7 @@ jobs:
         echo "response=$response" >> $GITHUB_OUTPUT
         
     - name: Check upload response
-      if: steps.upload-build-files.outputs.response != '' && fromJSON(steps.upload-build-files.outputs.response).type != ''
+      if: steps.upload-build-files.outputs.response != '' && fromJSON(steps.upload-build-files.outputs.response).status != ''
       run: |
         echo "::error ::Failed to upload files to build server. Resonse: ${{ steps.upload-build-files.outputs.response }}"
         exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -48,35 +48,30 @@ jobs:
         ext-ref: ${{ matrix.value.ref }}
         
     - name: Extract Extension Info
-      uses: rgarcia-phi/json-to-variables@9835d537368468c4e4de5254dc3efeadda183793
-      with:
-        filename: ${{ matrix.value.path }}/ExtensionManifest.json
-        prefix: ext
-        masked: false
+      run: echo "manifest=$(cat ${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_ENV
     
     - name: Debug Extension Info
       shell: bash
       run: |
         echo "[Extension Info Values]"
-        echo "Type                     : ${{ env.ext_type }}"
-        echo "Name                     : ${{ env.ext_name }}"
-        echo "Author                   : ${{ env.ext_author }}"
-        echo "GitHub Repository        : ${{ env.ext_repository }}"
-        echo "Package ID               : ${{ env.ext_packageId }}"
-        echo "Version                  : ${{ env.ext_version }}"
+        echo "Type                     : ${{ fromJSON(env.manifest).type }}"
+        echo "Name                     : ${{ fromJSON(env.manifest).name }}"
+        echo "Author                   : ${{ fromJSON(env.manifest).author }}"
+        echo "GitHub Repository        : ${{ fromJSON(env.manifest).repository }}"
+        echo "Package ID               : ${{ fromJSON(env.manifest).packageId }}"
+        echo "Version                  : ${{ fromJSON(env.manifest).version }}"
 
     - name: Validate Extension Info
       if: |
-        env.ext_type == '' || 
-        env.ext_name == '' || 
-        env.ext_author == '' || 
-        env.ext_repository == '' || 
-        env.ext_packageId == '' || 
-        env.ext_version == ''
+        fromJSON(env.manifest).type == '' || 
+        fromJSON(env.manifest).name == '' || 
+        fromJSON(env.manifest).author == '' || 
+        fromJSON(env.manifest).repository == '' || 
+        fromJSON(env.manifest).packageId == '' || 
+        fromJSON(env.manifest).version == ''
       shell: bash
       run: | 
-        echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"
-        exit 1
+        echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]" && exit 1
         
     - name: Download a Build Artifact
       uses: actions/download-artifact@v3.0.2
@@ -103,5 +98,4 @@ jobs:
         fromJSON(steps.upload-build-files.outputs.response).success == 'false' &&
         fromJSON(steps.upload-build-files.outputs.response).errorCode != 4
       run: |
-        echo "::error ::Failed to upload files to build server. Response: ${{ steps.upload-build-files.outputs.response }}"
-        exit 1
+        echo "::error ::Failed to upload files to build server. Response: ${{ steps.upload-build-files.outputs.response }}" && exit 1

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -21,7 +21,7 @@ jobs:
     - id: matrix
       run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\"}", $1, $2)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
     - name: Check matrix value
-      run: echo ${{ steps.matrix.outputs.value }}
+      run: echo "${{ steps.matrix.outputs.value }}"
 
   build:
     needs: [ setup ]

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -95,7 +95,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         curl --fail-with-body -o "./${{ fromJSON(env.manifest).packageId }}-upload-response.json" -X POST \
-          '${{ vars.EXTENSION_STORE_API_URL }}/extensions/files/Upload' \
+          '${{ vars.EXTENSION_STORE_API_URL }}/files/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -81,16 +81,6 @@ jobs:
       run: | 
         echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"
         exit 1
-  
-    - name: Check if new
-      id: check-if-new
-      run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' '${{ vars.EXTENSION_STORE_API_URL }}/extensions/${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
-        is_new=0
-        if [ $(($http_code)) -eq 404 ]; then
-          is_new=1
-        fi
-        echo "is_new=$is_new" >> $GITHUB_OUTPUT
         
     - name: Download a Build Artifact
       uses: actions/download-artifact@v3.0.2
@@ -104,7 +94,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         response=$(curl --fail-with-body -X POST \
-          '${{ vars.EXTENSION_STORE_API_URL }}/extensiosn/files/Upload' \
+          '${{ vars.EXTENSION_STORE_API_URL }}/extensions/files/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -50,19 +50,19 @@ jobs:
     - name: Extract Extension Info
       id: extension_info
       run: |
-        type=$(cat ./${{ matrix.value.path }} | node -pe 'JSON.parse(fs.readFileSync(0)).type')
+        type=$(cat ./${{ matrix.value.path }} | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).type')
         if [ $type -eq 0 ]; then
           type="Plugin"
         elif [ $type -eq 1 ];then
           type="IconPack"
         fi
         echo "EXT_TYPE=$type" >> $GITHUB_OUTPUT
-        echo "EXT_NAME=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).name')" >> $GITHUB_OUTPUT
-        echo "EXT_AUTHOR=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).author')" >> $GITHUB_OUTPUT
-        echo "EXT_REPO=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).repository')" >> $GITHUB_OUTPUT
-        echo "EXT_PACKAGE_ID=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).packageId')" >> $GITHUB_OUTPUT
-        echo "EXT_VERSION=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).version')" >> $GITHUB_OUTPUT
-        echo "EXT_D_SUPPORT_USER_ID=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(fs.readFileSync(0)).dSupportUserId')" >> $GITHUB_OUTPUT
+        echo "EXT_NAME=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).name')" >> $GITHUB_OUTPUT
+        echo "EXT_AUTHOR=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).author')" >> $GITHUB_OUTPUT
+        echo "EXT_REPO=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).repository')" >> $GITHUB_OUTPUT
+        echo "EXT_PACKAGE_ID=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).packageId')" >> $GITHUB_OUTPUT
+        echo "EXT_VERSION=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).version')" >> $GITHUB_OUTPUT
+        echo "EXT_D_SUPPORT_USER_ID=$(cat ./${{ matrix.value.path }}/ExtensionManifest.json | node -pe 'JSON.parse(require('fs').readFileSync('/dev/stdin')).dSupportUserId')" >> $GITHUB_OUTPUT
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -48,7 +48,7 @@ jobs:
         ext-ref: ${{ matrix.value.ref }}
         
     - name: Extract Extension Info
-      run: echo "manifest=$(cat ${{ matrix.value.path }}/ExtensionManifest.json)" >> $GITHUB_ENV
+      run: cat <(echo -n "manifest=") "${{ matrix.value.path }}/ExtensionManifest.json" >> $GITHUB_ENV
     
     - name: Debug Extension Info
       shell: bash

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -97,7 +97,7 @@ jobs:
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \
           -F 'file=@${{ steps.build_extension.outputs.artifact-path }};type=application/x-zip-compressed' || true
-        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json")
+        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json") | tr -d '\n'
         echo -e "Response:\n$response"
         echo "response=$response" >> $GITHUB_OUTPUT
         

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -41,7 +41,6 @@ jobs:
       
     - name: Build Extension
       id: build_extension
-      continue-on-error: true
       uses: RecklessBoon/Macro-Deck-Extension-Build-Action@main
       with:
         upsert-release: false
@@ -68,8 +67,11 @@ jobs:
         steps.extension_info.outputs.EXT_PACKAGE_ID == '' || 
         steps.extension_info.outputs.EXT_VERSION == ''
       shell: bash
+      run: echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"
+    
+    - name: Debug Extension Info
+      shell: bash
       run: |
-        echo "::error file=ExtensionManifest.json::Invalid manifest! Required attributes [version, type, packageId, target-plugin-api-version]"
         echo "[Extension Info Values]"
         echo "Type                     : ${{ steps.extension_info.outputs.EXT_TYPE }}"
         echo "Name                     : ${{ steps.extension_info.outputs.EXT_NAME }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -37,8 +37,7 @@ jobs:
                 awk 'NR > 1 {printf(\",\")} {printf(\"{\\\"repository\\\":\\\"%s\\\",\\\"ref\\\":\\\"%s\\\",\\\"path\\\":\\\"%s\\\"}\", \$1, \$2, \$3)}'
               ;;
           esac
-        " | cat <(echo -n 'value=[') - <(echo -n ']') 
-        git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1 $displaypath' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\",\"path\":\"%s\"}", $1, $2, $3)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
+        " | cat <(echo -n 'value=[') - <(echo -n ']') >> $GITHUB_OUTPUT
       
     - name: Check matrix value
       run: echo "${{ steps.matrix.outputs.value }}"

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Check if new
       id: check-if-new
       run:  |
-        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' '${{ env.EXTENSION_STORE_API_URL }}/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
+        http_code=$(curl -X 'GET' --silent --output /dev/null --write-out '%{http_code}' '${EXTENSION_STORE_API_URL}/Extensions${{ steps.extension_info.outputs.EXT_TYPE == 'Plugin' && '' || '/Icon' }}/${{ steps.extension_info.outputs.EXT_PACKAGE_ID }}')
         is_new=0
         if [ $(($http_code)) -eq 404 ]; then
           is_new=1
@@ -104,7 +104,7 @@ jobs:
         MACRO_DECK_API_AUTH: "Bearer ${{ secrets.MACRO_DECK_API_TOKEN }}"
       run: |
         response=$(curl -X POST \
-          '${{ env.EXTENSION_STORE_API_URL }}/ExtensionsFiles/Upload' \
+          '${EXTENSION_STORE_API_URL}/ExtensionsFiles/Upload' \
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -35,5 +35,5 @@ jobs:
       uses: RecklessBoon/Macro-Deck-Extension-Build-Action@main
       with:
         upsert-release: 'false'
-        ext-repo: ${{ matrix.repo }}
-        ext-ref: ${{ matrix.ref }}
+        ext-repo: ${{ matrix.value.repository }}
+        ext-ref: ${{ matrix.value.ref }}

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -71,7 +71,7 @@ jobs:
         tag=$(git tag --contains "${{ matrix.value.ref }}" | head -n 1)
         if [ -n "$tag" ]; then
           echo "Tag $tag found for commit $ref. Now looking for release..."
-          release_body=$(gh release view $tag --json body,name || true)
+          release=$(gh release view $tag --json body,name || true)
         fi
         if [ -n "$release" ]; then
           echo "Release found! $release"
@@ -158,8 +158,13 @@ jobs:
               "g":1,
               "b":1
             },
-            "title": "${{ matrix.value.path }} Deployed to Extension Store",
+            "title": "${{ matrix.value.path }}",
             "fields" : [
+              {
+                "name": "Version",
+                "value": "${{ fromJSON(steps.upload-build-files.outputs.response).currentVersion }} -> ${{ fromJSON(steps.upload-build-files.outputs.response).newVersion}}",
+                "inline": false
+              },
               {
                 "name": "Repository URL",
                 "value": "https://github.com/${{ matrix.value.repository }}",

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -48,11 +48,11 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       working-directory: ${{ matrix.value.path }}
       run: |
-        git fetch --all --tags --prune
+        git fetch --all --tags
         tag=$(git tag --contains "${{ matrix.value.ref }}" | head -n 1)
-        if [ -z "$tag" ]; then
+        if [ -n "$tag" ]; then
           echo "Tag $tag found for commit $ref. Now looking for release..."
-          release=$(gh release view $tag --json body)
+          release_body=$(gh release view $tag --json body)
         fi
         echo "release=$release" >> $GITHUB_ENV
       
@@ -147,7 +147,7 @@ jobs:
                 "name" : "SHA",
                 "value" : "${{ matrix.value.ref }}" , 
                 "inline" : false
-              }${{ env.response && format(',{ "name": "Changelog", "value": "%s", "inline": false }', fromJSON(env.response).body) }}
+              }${{ env.release && format(',{ "name": "Changelog", "value": "%s", "inline": false }', fromJSON(env.release).body) }}
             ]
           }
         }'

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -1,8 +1,6 @@
 name: Compile Extensions
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
     types: [ closed ]

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -105,6 +105,7 @@ jobs:
       run: |
         response=$(curl -X POST \
           '${{ vars.EXTENSION_STORE_API_URL }}/ExtensionsFiles/Upload' \
+          --fail-with-body \ 
           -H 'accept: */*' \
           -H "Authorization: $MACRO_DECK_API_AUTH" \
           -H 'Content-Type: multipart/form-data' \

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -152,7 +152,7 @@ jobs:
           -H 'Content-Type: application/json' \
           -d "$payload" || true
         failed=$?
-        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-upload-response.json")
+        response=$(cat "./${{ fromJSON(env.manifest).packageId }}-bot-notify-response.json")
         echo -e "Response:\n$response"
         if [ $failed -ne 0 ]; then 
           exit 1; 

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3.3.0
     - name: Init Submodules
-      run: git submodule update --init --recursive
+      run: git submodule update --init --recursive --checkout
     - id: matrix
       run: git submodule --quiet foreach 'echo `git remote get-url origin | sed "s/https:\/\/github\.com\///" | sed "s/\.git//"` $sha1 $displaypath' | awk 'NR > 1 {printf(",")} {printf("{\"repository\":\"%s\",\"ref\":\"%s\",\"path\":\"%s\"}", $1, $2, $3)}' | cat <(echo -n "value=[") - <(echo -n "]") >> $GITHUB_OUTPUT
     - name: Check matrix value

--- a/.github/workflows/compile_extensions.yml
+++ b/.github/workflows/compile_extensions.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         delim="EOF-${RANDOM}"
         echo "manifest<<${delim}" >> $GITHUB_ENV
-        cat "${{ matrix.value.path }}/ExtensionManifest.json" | perl -pe 'chome if eof' >> $GITHUB_ENV
+        cat "${{ matrix.value.path }}/ExtensionManifest.json" | dos2unix | perl -pe 'chome if eof' >> $GITHUB_ENV
         echo -e "\n${delim}" >> $GITHUB_ENV
     
     - name: Debug Extension Info


### PR DESCRIPTION
<!--- Please fill out the following template -->

### Description (Only required for new plugins)
This really just adds one file, and maybe a plugin update, that allows the repo owner to compile all extensions manually as well as compile an extension automatically for an accepted Pull Request.

This will require an environment with secrets and variables set up to work.

WHEN MERGING YOU SHOULD SQUASH AND MERGE. I was too lazy to do it offline 😪 

### How has this been tested? (Only required for plugins)
Very numerous times via GitHub on my own repo