### PR TITLE
New Ize.HWiNFO64 Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -169,3 +169,6 @@
 [submodule "Plugins/Ize.Speedtest"]
 	path = Plugins/Ize.Speedtest
 	url = https://github.com/Ize83/Ize.Speedtest
+[submodule "Plugins/Ize.HWiNFO64"]
+	path = Plugins/Ize.HWiNFO64
+	url = https://github.com/Ize83/Ize.HWiNFO64


### PR DESCRIPTION
<!--- Please fill out the following template -->

### Description (Only required for new plugins)
Allows to show ALL sensor data from HWiNFO64 in Macro-Deck

### On which Macro Deck Version has this been tested/created?
2.12.0

### How has this been tested? (Only required for plugins)
Build and testet on my local machine. I've also tried to install the plugin from zip to see if the configurator comes up, everything worked fine.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I used the workflow to add the Extension ([described here](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#add-your-extension-to-the-extension-store))
- [X] I have not added any files manually to the Macro-Deck-Extensions repository
- [X] The added Extension is tested and works
- [X] The added Extension meets [the rules](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#rules)
- [X] The repository of my Extension meets the [required file structure](https://github.com/Macro-Deck-org/Macro-Deck-Extensions#repository-root-file-structure)
