### PR TITLE
Remove Plugins/Ize.HWiNFO64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -169,6 +169,3 @@
 [submodule "Plugins/Ize.Speedtest"]
 	path = Plugins/Ize.Speedtest
 	url = https://github.com/Ize83/Ize.Speedtest
-[submodule "Plugins/Ize.HWiNFO64"]
-	path = Plugins/Ize.HWiNFO64
-	url = https://github.com/Ize83/Ize.HWiNFO64


### PR DESCRIPTION
Removed the plugin because for some users, Macro Deck refuses to start with this plugin and the author did not fix it in time.