### PR TITLE
 Add new plugin "LibreHardwareMonitor plugin" 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -196,3 +196,6 @@
 [submodule "Plugins/FarLemon.JsonUtilityPlugin"]
 	path = Plugins/FarLemon.JsonUtilityPlugin
 	url = https://github.com/FarLemon/Macro-Deck-JSON-Utility-Plugin.git
+[submodule "Plugins/ItaiMarom.LibreHardwareMonitorPlugin"]
+	path = Plugins/ItaiMarom.LibreHardwareMonitorPlugin
+	url = https://github.com/dominic25/ItaiMarom.LibreHardwareMonitorPlugin


### PR DESCRIPTION
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I used the latest version to develop and test the Extension
- [x] I used the workflow to add the Extension ([described here](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#add-your-extension-to-the-extension-store))
- [x] I have not added any files manually to the Macro-Deck-Extensions repository
- [x] The added Extension is tested and works
- [x] The added Extension meets [the rules](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#rules)
- [x] The repository of my Extension meets the [required file structure](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#repository-root-file-structure)
