### PR TITLE
Multi-Display VCP Client

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -208,3 +208,6 @@
 [submodule "Plugins/Stubbs.HellDivers2Strats"]
 	path = Plugins/Stubbs.HellDivers2Strats
 	url = https://github.com/rstubbs94/Stubbs.HellDivers2Strats
+[submodule "Plugins/DoggoDogPack.MultiDisplayVCPClient"]
+	path = Plugins/DoggoDogPack.MultiDisplayVCPClient
+	url = https://github.com/dog199200/MultiDisplayVCPClient


### PR DESCRIPTION
This is an extension plugin for Macro Deck (https://macro-deck.app/). It acts as an end-to-end extension with the Multi-Display VCP Server (https://github.com/dog199200/MultiDisplayVCPServer) allowing you to get and control settings from Monitors/Displays on any computer in the network running the server.
