### PR TITLE
[Plugin Update] felba.SpotifyAlbumCoverPlugin => 0.1.0

### DIFF
--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: false
+          fetch-depth: 0
       - name: Use token for submodules
         run: |
           git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
@@ -52,9 +55,7 @@ jobs:
         shell: bash
         run: | 
           git clean -xfd
-          git submodule foreach --recursive git clean -xfd
           git reset --hard
-          git submodule foreach --recursive git reset --hard
           if [ -d "./${{ env.output_path }}/${{ env.package_id }}" ]; then
             git submodule update --init --recursive ./${{ env.output_path }}/${{ env.package_id }}
           fi

--- a/.github/workflows/extension_upsert.yml
+++ b/.github/workflows/extension_upsert.yml
@@ -22,7 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+      - name: Use token for submodules
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
       - name: Get manifest details
         run: |
           rm -rf ../temp

--- a/.gitmodules
+++ b/.gitmodules
@@ -208,3 +208,6 @@
 [submodule "Plugins/Stubbs.HellDivers2Strats"]
 	path = Plugins/Stubbs.HellDivers2Strats
 	url = https://github.com/rstubbs94/Stubbs.HellDivers2Strats
+[submodule "Plugins/felba.SpotifyAlbumCoverPlugin"]
+	path = Plugins/felba.SpotifyAlbumCoverPlugin
+	url = https://github.com/felpower/Macro-Deck-Spotify-Album-Cover-Plugin


### PR DESCRIPTION
## Plugin Update

Adds Spotify Album Cover Plugin to the Macro Deck Extension Store.

- Repo: https://github.com/felpower/Macro-Deck-Spotify-Album-Cover-Plugin
- Package ID: felba.SpotifyAlbumCoverPlugin
- Version: v0.1.0
- Type: Plugin

### Checklist:
- [x] I used the latest version to develop and test the Extension
- [x] I used the workflow to add the Extension (described in the README)
- [x] I have not added any files manually to the Macro-Deck-Extensions repository
- [x] The added Extension is tested and works
- [x] The added Extension meets the rules
- [x] The repository of my Extension meets the required file structure