### PR TITLE
MDBridgeSpicetify ; an app to have macrodeck interact with Spicetify to control spotify. (fixed)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -217,3 +217,6 @@
 [submodule "Plugins/sugoides.HWiNFO64"]
 	path = Plugins/sugoides.HWiNFO64
 	url = https://github.com/sugoides/macro-deck-HWiNFO64-plugin
+[submodule "Plugins/Niyah.SpicetifyBridge"]
+	path = Plugins/Niyah.SpicetifyBridge
+	url = https://github.com/NiyahVE/MDBridgeSpicetify


### PR DESCRIPTION
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I used the latest version to develop and test the Extension
- [x] I used the workflow to add the Extension ([described here](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#add-your-extension-to-the-extension-store))
- [x] I have not added any files manually to the Macro-Deck-Extensions repository
- [x] The added Extension is tested and works
- [x] The added Extension meets [the rules](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#rules)
- [x] The repository of my Extension meets the [required file structure](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#repository-root-file-structure)
