### PR TITLE
Add CS2 GSI for Macro Deck

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -226,3 +226,6 @@
 [submodule "Plugins/DaNeo.Teamspeak3Plugin"]
 	path = Plugins/DaNeo.Teamspeak3Plugin
 	url = https://github.com/DaNeo61/Teamspeak3Plugin.git
+[submodule "Plugins/LeoM.Cs2Gsi"]
+	path = Plugins/LeoM.Cs2Gsi
+	url = https://github.com/leo-divini/CS2_Macro_Deck_Plugin


### PR DESCRIPTION
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I used the latest version to develop and test the Extension
- [x] I used the workflow to add the Extension ([described here](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#add-your-extension-to-the-extension-store))
- [x] I have not added any files manually to the Macro-Deck-Extensions repository
- [x] The added Extension is tested and works
- [x] The added Extension meets [the rules](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#rules)
- [x] The repository of my Extension meets the [required file structure](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#repository-root-file-structure)


  Adds LeoM.Cs2Gsi, a Macro Deck plugin for
  Counter-Strike 2 Game State Integration
  variables.

  Tested with:
  - Macro Deck 2.15.0-b1
  - CS2 real GSI payloads
  - listener status, token_invalid, port_in_use